### PR TITLE
Added compilation compatability for Windows users

### DIFF
--- a/libs/include/SFML/Audio.hpp
+++ b/libs/include/SFML/Audio.hpp
@@ -1,0 +1,56 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_AUDIO_HPP
+#define SFML_AUDIO_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
+#include <SFML/System.hpp>
+#include <SFML/Audio/InputSoundFile.hpp>
+#include <SFML/Audio/Listener.hpp>
+#include <SFML/Audio/Music.hpp>
+#include <SFML/Audio/OutputSoundFile.hpp>
+#include <SFML/Audio/Sound.hpp>
+#include <SFML/Audio/SoundBuffer.hpp>
+#include <SFML/Audio/SoundBufferRecorder.hpp>
+#include <SFML/Audio/SoundFileFactory.hpp>
+#include <SFML/Audio/SoundFileReader.hpp>
+#include <SFML/Audio/SoundFileWriter.hpp>
+#include <SFML/Audio/SoundRecorder.hpp>
+#include <SFML/Audio/SoundSource.hpp>
+#include <SFML/Audio/SoundStream.hpp>
+
+
+#endif // SFML_AUDIO_HPP
+
+////////////////////////////////////////////////////////////
+/// \defgroup audio Audio module
+///
+/// Sounds, streaming (musics or custom sources), recording,
+/// spatialization.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/AlResource.hpp
+++ b/libs/include/SFML/Audio/AlResource.hpp
@@ -1,0 +1,70 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_ALRESOURCE_HPP
+#define SFML_ALRESOURCE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Base class for classes that require an OpenAL context
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API AlResource
+{
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    AlResource();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~AlResource();
+};
+
+} // namespace sf
+
+
+#endif // SFML_ALRESOURCE_HPP
+
+////////////////////////////////////////////////////////////
+/// \class sf::AlResource
+/// \ingroup audio
+///
+/// This class is for internal use only, it must be the base
+/// of every class that requires a valid OpenAL context in
+/// order to work.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/Export.hpp
+++ b/libs/include/SFML/Audio/Export.hpp
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_AUDIO_EXPORT_HPP
+#define SFML_AUDIO_EXPORT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+////////////////////////////////////////////////////////////
+// Define portable import / export macros
+////////////////////////////////////////////////////////////
+#if defined(SFML_AUDIO_EXPORTS)
+
+    #define SFML_AUDIO_API SFML_API_EXPORT
+
+#else
+
+    #define SFML_AUDIO_API SFML_API_IMPORT
+
+#endif
+
+
+#endif // SFML_AUDIO_EXPORT_HPP

--- a/libs/include/SFML/Audio/InputSoundFile.hpp
+++ b/libs/include/SFML/Audio/InputSoundFile.hpp
@@ -1,0 +1,263 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_INPUTSOUNDFILE_HPP
+#define SFML_INPUTSOUNDFILE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/Time.hpp>
+#include <string>
+#include <algorithm>
+
+
+namespace sf
+{
+class InputStream;
+class SoundFileReader;
+
+////////////////////////////////////////////////////////////
+/// \brief Provide read access to sound files
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API InputSoundFile : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    InputSoundFile();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~InputSoundFile();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a sound file from the disk for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param filename Path of the sound file to load
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    bool openFromFile(const std::string& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a sound file in memory for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    bool openFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a sound file from a custom stream for reading
+    ///
+    /// The supported audio formats are: WAV (PCM only), OGG/Vorbis, FLAC.
+    /// The supported sample sizes for FLAC and WAV are 8, 16, 24 and 32 bit.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    bool openFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the total number of audio samples in the file
+    ///
+    /// \return Number of samples
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint64 getSampleCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the number of channels used by the sound
+    ///
+    /// \return Number of channels (1 = mono, 2 = stereo)
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getChannelCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the sample rate of the sound
+    ///
+    /// \return Sample rate, in samples per second
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getSampleRate() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the total duration of the sound file
+    ///
+    /// This function is provided for convenience, the duration is
+    /// deduced from the other sound file attributes.
+    ///
+    /// \return Duration of the sound file
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getDuration() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the read offset of the file in time
+    ///
+    /// \return Time position
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getTimeOffset() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the read offset of the file in samples
+    ///
+    /// \return Sample position
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint64 getSampleOffset() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current read position to the given sample offset
+    ///
+    /// This function takes a sample offset to provide maximum
+    /// precision. If you need to jump to a given time, use the
+    /// other overload.
+    ///
+    /// The sample offset takes the channels into account.
+    /// If you have a time offset instead, you can easily find
+    /// the corresponding sample offset with the following formula:
+    /// `timeInSeconds * sampleRate * channelCount`
+    /// If the given offset exceeds to total number of samples,
+    /// this function jumps to the end of the sound file.
+    ///
+    /// \param sampleOffset Index of the sample to jump to, relative to the beginning
+    ///
+    ////////////////////////////////////////////////////////////
+    void seek(Uint64 sampleOffset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current read position to the given time offset
+    ///
+    /// Using a time offset is handy but imprecise. If you need an accurate
+    /// result, consider using the overload which takes a sample offset.
+    ///
+    /// If the given time exceeds to total duration, this function jumps
+    /// to the end of the sound file.
+    ///
+    /// \param timeOffset Time to jump to, relative to the beginning
+    ///
+    ////////////////////////////////////////////////////////////
+    void seek(Time timeOffset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Read audio samples from the open file
+    ///
+    /// \param samples  Pointer to the sample array to fill
+    /// \param maxCount Maximum number of samples to read
+    ///
+    /// \return Number of samples actually read (may be less than \a maxCount)
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint64 read(Int16* samples, Uint64 maxCount);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Close the current file
+    ///
+    ////////////////////////////////////////////////////////////
+    void close();
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    SoundFileReader* m_reader;       ///< Reader that handles I/O on the file's format
+    InputStream*     m_stream;       ///< Input stream used to access the file's data
+    bool             m_streamOwned;  ///< Is the stream internal or external?
+    Uint64           m_sampleOffset; ///< Sample Read Position
+    Uint64           m_sampleCount;  ///< Total number of samples in the file
+    unsigned int     m_channelCount; ///< Number of channels of the sound
+    unsigned int     m_sampleRate;   ///< Number of samples per second
+};
+
+} // namespace sf
+
+
+#endif // SFML_INPUTSOUNDFILE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::InputSoundFile
+/// \ingroup audio
+///
+/// This class decodes audio samples from a sound file. It is
+/// used internally by higher-level classes such as sf::SoundBuffer
+/// and sf::Music, but can also be useful if you want to process
+/// or analyze audio files without playing them, or if you want to
+/// implement your own version of sf::Music with more specific
+/// features.
+///
+/// Usage example:
+/// \code
+/// // Open a sound file
+/// sf::InputSoundFile file;
+/// if (!file.openFromFile("music.ogg"))
+///     /* error */;
+///
+/// // Print the sound attributes
+/// std::cout << "duration: " << file.getDuration().asSeconds() << std::endl;
+/// std::cout << "channels: " << file.getChannelCount() << std::endl;
+/// std::cout << "sample rate: " << file.getSampleRate() << std::endl;
+/// std::cout << "sample count: " << file.getSampleCount() << std::endl;
+///
+/// // Read and process batches of samples until the end of file is reached
+/// sf::Int16 samples[1024];
+/// sf::Uint64 count;
+/// do
+/// {
+///     count = file.read(samples, 1024);
+///
+///     // process, analyze, play, convert, or whatever
+///     // you want to do with the samples...
+/// }
+/// while (count > 0);
+/// \endcode
+///
+/// \see sf::SoundFileReader, sf::OutputSoundFile
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/Listener.hpp
+++ b/libs/include/SFML/Audio/Listener.hpp
@@ -1,0 +1,234 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_LISTENER_HPP
+#define SFML_LISTENER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/System/Vector3.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief The audio listener is the point in the scene
+///        from where all the sounds are heard
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API Listener
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the global volume of all the sounds and musics
+    ///
+    /// The volume is a number between 0 and 100; it is combined with
+    /// the individual volume of each sound / music.
+    /// The default value for the volume is 100 (maximum).
+    ///
+    /// \param volume New global volume, in the range [0, 100]
+    ///
+    /// \see getGlobalVolume
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setGlobalVolume(float volume);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current value of the global volume
+    ///
+    /// \return Current global volume, in the range [0, 100]
+    ///
+    /// \see setGlobalVolume
+    ///
+    ////////////////////////////////////////////////////////////
+    static float getGlobalVolume();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the position of the listener in the scene
+    ///
+    /// The default listener's position is (0, 0, 0).
+    ///
+    /// \param x X coordinate of the listener's position
+    /// \param y Y coordinate of the listener's position
+    /// \param z Z coordinate of the listener's position
+    ///
+    /// \see getPosition, setDirection
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setPosition(float x, float y, float z);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the position of the listener in the scene
+    ///
+    /// The default listener's position is (0, 0, 0).
+    ///
+    /// \param position New listener's position
+    ///
+    /// \see getPosition, setDirection
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setPosition(const Vector3f& position);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current position of the listener in the scene
+    ///
+    /// \return Listener's position
+    ///
+    /// \see setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    static Vector3f getPosition();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the forward vector of the listener in the scene
+    ///
+    /// The direction (also called "at vector") is the vector
+    /// pointing forward from the listener's perspective. Together
+    /// with the up vector, it defines the 3D orientation of the
+    /// listener in the scene. The direction vector doesn't
+    /// have to be normalized.
+    /// The default listener's direction is (0, 0, -1).
+    ///
+    /// \param x X coordinate of the listener's direction
+    /// \param y Y coordinate of the listener's direction
+    /// \param z Z coordinate of the listener's direction
+    ///
+    /// \see getDirection, setUpVector, setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setDirection(float x, float y, float z);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the forward vector of the listener in the scene
+    ///
+    /// The direction (also called "at vector") is the vector
+    /// pointing forward from the listener's perspective. Together
+    /// with the up vector, it defines the 3D orientation of the
+    /// listener in the scene. The direction vector doesn't
+    /// have to be normalized.
+    /// The default listener's direction is (0, 0, -1).
+    ///
+    /// \param direction New listener's direction
+    ///
+    /// \see getDirection, setUpVector, setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setDirection(const Vector3f& direction);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current forward vector of the listener in the scene
+    ///
+    /// \return Listener's forward vector (not normalized)
+    ///
+    /// \see setDirection
+    ///
+    ////////////////////////////////////////////////////////////
+    static Vector3f getDirection();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the upward vector of the listener in the scene
+    ///
+    /// The up vector is the vector that points upward from the
+    /// listener's perspective. Together with the direction, it
+    /// defines the 3D orientation of the listener in the scene.
+    /// The up vector doesn't have to be normalized.
+    /// The default listener's up vector is (0, 1, 0). It is usually
+    /// not necessary to change it, especially in 2D scenarios.
+    ///
+    /// \param x X coordinate of the listener's up vector
+    /// \param y Y coordinate of the listener's up vector
+    /// \param z Z coordinate of the listener's up vector
+    ///
+    /// \see getUpVector, setDirection, setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setUpVector(float x, float y, float z);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the upward vector of the listener in the scene
+    ///
+    /// The up vector is the vector that points upward from the
+    /// listener's perspective. Together with the direction, it
+    /// defines the 3D orientation of the listener in the scene.
+    /// The up vector doesn't have to be normalized.
+    /// The default listener's up vector is (0, 1, 0). It is usually
+    /// not necessary to change it, especially in 2D scenarios.
+    ///
+    /// \param upVector New listener's up vector
+    ///
+    /// \see getUpVector, setDirection, setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setUpVector(const Vector3f& upVector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current upward vector of the listener in the scene
+    ///
+    /// \return Listener's upward vector (not normalized)
+    ///
+    /// \see setUpVector
+    ///
+    ////////////////////////////////////////////////////////////
+    static Vector3f getUpVector();
+};
+
+} // namespace sf
+
+
+#endif // SFML_LISTENER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Listener
+/// \ingroup audio
+///
+/// The audio listener defines the global properties of the
+/// audio environment, it defines where and how sounds and musics
+/// are heard. If sf::View is the eyes of the user, then sf::Listener
+/// is his ears (by the way, they are often linked together --
+/// same position, orientation, etc.).
+///
+/// sf::Listener is a simple interface, which allows to setup the
+/// listener in the 3D audio environment (position, direction and
+/// up vector), and to adjust the global volume.
+///
+/// Because the listener is unique in the scene, sf::Listener only
+/// contains static functions and doesn't have to be instantiated.
+///
+/// Usage example:
+/// \code
+/// // Move the listener to the position (1, 0, -5)
+/// sf::Listener::setPosition(1, 0, -5);
+///
+/// // Make it face the right axis (1, 0, 0)
+/// sf::Listener::setDirection(1, 0, 0);
+///
+/// // Reduce the global volume
+/// sf::Listener::setGlobalVolume(50);
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/Music.hpp
+++ b/libs/include/SFML/Audio/Music.hpp
@@ -1,0 +1,337 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_MUSIC_HPP
+#define SFML_MUSIC_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/Audio/SoundStream.hpp>
+#include <SFML/Audio/InputSoundFile.hpp>
+#include <SFML/System/Mutex.hpp>
+#include <SFML/System/Time.hpp>
+#include <string>
+#include <vector>
+
+
+namespace sf
+{
+class InputStream;
+
+////////////////////////////////////////////////////////////
+/// \brief Streamed music played from an audio file
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API Music : public SoundStream
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Structure defining a time range using the template type
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    struct Span
+    {
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        ////////////////////////////////////////////////////////////
+        Span()
+        {
+
+        }
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Initialization constructor
+        ///
+        /// \param off Initial Offset
+        /// \param len Initial Length
+        ///
+        ////////////////////////////////////////////////////////////
+        Span(T off, T len):
+        offset(off),
+        length(len)
+        {
+
+        }
+
+        T offset; ///< The beginning offset of the time range
+        T length; ///< The length of the time range
+    };
+
+    // Define the relevant Span types
+    typedef Span<Time> TimeSpan;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Music();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Music();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a music from an audio file
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather
+    /// streamed continuously, the file must remain accessible until
+    /// the sf::Music object loads a new music or is destroyed.
+    ///
+    /// \param filename Path of the music file to open
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see openFromMemory, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool openFromFile(const std::string& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a music from an audio file in memory
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather streamed
+    /// continuously, the \a data buffer must remain accessible until
+    /// the sf::Music object loads a new music or is destroyed. That is,
+    /// you can't deallocate the buffer right after calling this function.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see openFromFile, openFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool openFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a music from an audio file in a custom stream
+    ///
+    /// This function doesn't start playing the music (call play()
+    /// to do so).
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \warning Since the music is not loaded at once but rather
+    /// streamed continuously, the \a stream must remain accessible
+    /// until the sf::Music object loads a new music or is destroyed.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see openFromFile, openFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    bool openFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the total duration of the music
+    ///
+    /// \return Music duration
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getDuration() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the positions of the of the sound's looping sequence
+    ///
+    /// \return Loop Time position class.
+    ///
+    /// \warning Since setLoopPoints() performs some adjustments on the
+    /// provided values and rounds them to internal samples, a call to
+    /// getLoopPoints() is not guaranteed to return the same times passed
+    /// into a previous call to setLoopPoints(). However, it is guaranteed
+    /// to return times that will map to the valid internal samples of
+    /// this Music if they are later passed to setLoopPoints().
+    ///
+    /// \see setLoopPoints
+    ///
+    ////////////////////////////////////////////////////////////
+    TimeSpan getLoopPoints() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sets the beginning and end of the sound's looping sequence using sf::Time
+    ///
+    /// Loop points allow one to specify a pair of positions such that, when the music
+    /// is enabled for looping, it will seamlessly seek to the beginning whenever it
+    /// encounters the end. Valid ranges for timePoints.offset and timePoints.length are
+    /// [0, Dur) and (0, Dur-offset] respectively, where Dur is the value returned by getDuration().
+    /// Note that the EOF "loop point" from the end to the beginning of the stream is still honored,
+    /// in case the caller seeks to a point after the end of the loop range. This function can be
+    /// safely called at any point after a stream is opened, and will be applied to a playing sound
+    /// without affecting the current playing offset.
+    ///
+    /// \warning Setting the loop points while the stream's status is Paused
+    /// will set its status to Stopped. The playing offset will be unaffected.
+    ///
+    /// \param timePoints The definition of the loop. Can be any time points within the sound's length
+    ///
+    /// \see getLoopPoints
+    ///
+    ////////////////////////////////////////////////////////////
+    void setLoopPoints(TimeSpan timePoints);
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Request a new chunk of audio samples from the stream source
+    ///
+    /// This function fills the chunk from the next samples
+    /// to read from the audio file.
+    ///
+    /// \param data Chunk of data to fill
+    ///
+    /// \return True to continue playback, false to stop
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool onGetData(Chunk& data);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current playing position in the stream source
+    ///
+    /// \param timeOffset New playing position, from the beginning of the music
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onSeek(Time timeOffset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current playing position in the stream source to the loop offset
+    ///
+    /// This is called by the underlying SoundStream whenever it needs us to reset
+    /// the seek position for a loop. We then determine whether we are looping on a
+    /// loop point or the end-of-file, perform the seek, and return the new position.
+    ///
+    /// \return The seek position after looping (or -1 if there's no loop)
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 onLoop();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Initialize the internal state after loading a new music
+    ///
+    ////////////////////////////////////////////////////////////
+    void initialize();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Helper to convert an sf::Time to a sample position
+    ///
+    /// \param position Time to convert to samples
+    ///
+    /// \return The number of samples elapsed at the given time
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint64 timeToSamples(Time position) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Helper to convert a sample position to an sf::Time
+    ///
+    /// \param samples Sample count to convert to Time
+    ///
+    /// \return The Time position of the given sample
+    ///
+    ////////////////////////////////////////////////////////////
+    Time samplesToTime(Uint64 samples) const;
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    InputSoundFile     m_file;     ///< The streamed music file
+    std::vector<Int16> m_samples;  ///< Temporary buffer of samples
+    Mutex              m_mutex;    ///< Mutex protecting the data
+    Span<Uint64>       m_loopSpan; ///< Loop Range Specifier
+};
+
+} // namespace sf
+
+
+#endif // SFML_MUSIC_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Music
+/// \ingroup audio
+///
+/// Musics are sounds that are streamed rather than completely
+/// loaded in memory. This is especially useful for compressed
+/// musics that usually take hundreds of MB when they are
+/// uncompressed: by streaming it instead of loading it entirely,
+/// you avoid saturating the memory and have almost no loading delay.
+/// This implies that the underlying resource (file, stream or
+/// memory buffer) must remain valid for the lifetime of the
+/// sf::Music object.
+///
+/// Apart from that, a sf::Music has almost the same features as
+/// the sf::SoundBuffer / sf::Sound pair: you can play/pause/stop
+/// it, request its parameters (channels, sample rate), change
+/// the way it is played (pitch, volume, 3D position, ...), etc.
+///
+/// As a sound stream, a music is played in its own thread in order
+/// not to block the rest of the program. This means that you can
+/// leave the music alone after calling play(), it will manage itself
+/// very well.
+///
+/// Usage example:
+/// \code
+/// // Declare a new music
+/// sf::Music music;
+///
+/// // Open it from an audio file
+/// if (!music.openFromFile("music.ogg"))
+/// {
+///     // error...
+/// }
+///
+/// // Change some parameters
+/// music.setPosition(0, 1, 10); // change its 3D position
+/// music.setPitch(2);           // increase the pitch
+/// music.setVolume(50);         // reduce the volume
+/// music.setLoop(true);         // make it loop
+///
+/// // Play it
+/// music.play();
+/// \endcode
+///
+/// \see sf::Sound, sf::SoundStream
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/OutputSoundFile.hpp
+++ b/libs/include/SFML/Audio/OutputSoundFile.hpp
@@ -1,0 +1,133 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_OUTPUTSOUNDFILE_HPP
+#define SFML_OUTPUTSOUNDFILE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <string>
+
+
+namespace sf
+{
+class SoundFileWriter;
+
+////////////////////////////////////////////////////////////
+/// \brief Provide write access to sound files
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API OutputSoundFile : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    OutputSoundFile();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// Closes the file if it was still open.
+    ///
+    ////////////////////////////////////////////////////////////
+    ~OutputSoundFile();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open the sound file from the disk for writing
+    ///
+    /// The supported audio formats are: WAV, OGG/Vorbis, FLAC.
+    ///
+    /// \param filename     Path of the sound file to write
+    /// \param sampleRate   Sample rate of the sound
+    /// \param channelCount Number of channels in the sound
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    bool openFromFile(const std::string& filename, unsigned int sampleRate, unsigned int channelCount);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Write audio samples to the file
+    ///
+    /// \param samples     Pointer to the sample array to write
+    /// \param count       Number of samples to write
+    ///
+    ////////////////////////////////////////////////////////////
+    void write(const Int16* samples, Uint64 count);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Close the current file
+    ///
+    ////////////////////////////////////////////////////////////
+    void close();
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    SoundFileWriter* m_writer; ///< Writer that handles I/O on the file's format
+};
+
+} // namespace sf
+
+
+#endif // SFML_OUTPUTSOUNDFILE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::OutputSoundFile
+/// \ingroup audio
+///
+/// This class encodes audio samples to a sound file. It is
+/// used internally by higher-level classes such as sf::SoundBuffer,
+/// but can also be useful if you want to create audio files from
+/// custom data sources, like generated audio samples.
+///
+/// Usage example:
+/// \code
+/// // Create a sound file, ogg/vorbis format, 44100 Hz, stereo
+/// sf::OutputSoundFile file;
+/// if (!file.openFromFile("music.ogg", 44100, 2))
+///     /* error */;
+///
+/// while (...)
+/// {
+///     // Read or generate audio samples from your custom source
+///     std::vector<sf::Int16> samples = ...;
+///
+///     // Write them to the file
+///     file.write(samples.data(), samples.size());
+/// }
+/// \endcode
+///
+/// \see sf::SoundFileWriter, sf::InputSoundFile
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/Sound.hpp
+++ b/libs/include/SFML/Audio/Sound.hpp
@@ -1,0 +1,264 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUND_HPP
+#define SFML_SOUND_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/Audio/SoundSource.hpp>
+#include <SFML/System/Time.hpp>
+#include <cstdlib>
+
+
+namespace sf
+{
+class SoundBuffer;
+
+////////////////////////////////////////////////////////////
+/// \brief Regular sound that can be played in the audio environment
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API Sound : public SoundSource
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Sound();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sound with a buffer
+    ///
+    /// \param buffer Sound buffer containing the audio data to play with the sound
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Sound(const SoundBuffer& buffer);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    Sound(const Sound& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Sound();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Start or resume playing the sound
+    ///
+    /// This function starts the stream if it was stopped, resumes
+    /// it if it was paused, and restarts it from beginning if it
+    /// was it already playing.
+    /// This function uses its own thread so that it doesn't block
+    /// the rest of the program while the sound is played.
+    ///
+    /// \see pause, stop
+    ///
+    ////////////////////////////////////////////////////////////
+    void play();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Pause the sound
+    ///
+    /// This function pauses the sound if it was playing,
+    /// otherwise (sound already paused or stopped) it has no effect.
+    ///
+    /// \see play, stop
+    ///
+    ////////////////////////////////////////////////////////////
+    void pause();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief stop playing the sound
+    ///
+    /// This function stops the sound if it was playing or paused,
+    /// and does nothing if it was already stopped.
+    /// It also resets the playing position (unlike pause()).
+    ///
+    /// \see play, pause
+    ///
+    ////////////////////////////////////////////////////////////
+    void stop();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the source buffer containing the audio data to play
+    ///
+    /// It is important to note that the sound buffer is not copied,
+    /// thus the sf::SoundBuffer instance must remain alive as long
+    /// as it is attached to the sound.
+    ///
+    /// \param buffer Sound buffer to attach to the sound
+    ///
+    /// \see getBuffer
+    ///
+    ////////////////////////////////////////////////////////////
+    void setBuffer(const SoundBuffer& buffer);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set whether or not the sound should loop after reaching the end
+    ///
+    /// If set, the sound will restart from beginning after
+    /// reaching the end and so on, until it is stopped or
+    /// setLoop(false) is called.
+    /// The default looping state for sound is false.
+    ///
+    /// \param loop True to play in loop, false to play once
+    ///
+    /// \see getLoop
+    ///
+    ////////////////////////////////////////////////////////////
+    void setLoop(bool loop);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current playing position of the sound
+    ///
+    /// The playing position can be changed when the sound is
+    /// either paused or playing. Changing the playing position
+    /// when the sound is stopped has no effect, since playing
+    /// the sound will reset its position.
+    ///
+    /// \param timeOffset New playing position, from the beginning of the sound
+    ///
+    /// \see getPlayingOffset
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPlayingOffset(Time timeOffset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the audio buffer attached to the sound
+    ///
+    /// \return Sound buffer attached to the sound (can be NULL)
+    ///
+    ////////////////////////////////////////////////////////////
+    const SoundBuffer* getBuffer() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the sound is in loop mode
+    ///
+    /// \return True if the sound is looping, false otherwise
+    ///
+    /// \see setLoop
+    ///
+    ////////////////////////////////////////////////////////////
+    bool getLoop() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current playing position of the sound
+    ///
+    /// \return Current playing position, from the beginning of the sound
+    ///
+    /// \see setPlayingOffset
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getPlayingOffset() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current status of the sound (stopped, paused, playing)
+    ///
+    /// \return Current status of the sound
+    ///
+    ////////////////////////////////////////////////////////////
+    Status getStatus() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    Sound& operator =(const Sound& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Reset the internal buffer of the sound
+    ///
+    /// This function is for internal use only, you don't have
+    /// to use it. It is called by the sf::SoundBuffer that
+    /// this sound uses, when it is destroyed in order to prevent
+    /// the sound from using a dead buffer.
+    ///
+    ////////////////////////////////////////////////////////////
+    void resetBuffer();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    const SoundBuffer* m_buffer; ///< Sound buffer bound to the source
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOUND_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Sound
+/// \ingroup audio
+///
+/// sf::Sound is the class to use to play sounds.
+/// It provides:
+/// \li Control (play, pause, stop)
+/// \li Ability to modify output parameters in real-time (pitch, volume, ...)
+/// \li 3D spatial features (position, attenuation, ...).
+///
+/// sf::Sound is perfect for playing short sounds that can
+/// fit in memory and require no latency, like foot steps or
+/// gun shots. For longer sounds, like background musics
+/// or long speeches, rather see sf::Music (which is based
+/// on streaming).
+///
+/// In order to work, a sound must be given a buffer of audio
+/// data to play. Audio data (samples) is stored in sf::SoundBuffer,
+/// and attached to a sound with the setBuffer() function.
+/// The buffer object attached to a sound must remain alive
+/// as long as the sound uses it. Note that multiple sounds
+/// can use the same sound buffer at the same time.
+///
+/// Usage example:
+/// \code
+/// sf::SoundBuffer buffer;
+/// buffer.loadFromFile("sound.wav");
+///
+/// sf::Sound sound;
+/// sound.setBuffer(buffer);
+/// sound.play();
+/// \endcode
+///
+/// \see sf::SoundBuffer, sf::Music
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/SoundBuffer.hpp
+++ b/libs/include/SFML/Audio/SoundBuffer.hpp
@@ -1,0 +1,352 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUNDBUFFER_HPP
+#define SFML_SOUNDBUFFER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/Audio/AlResource.hpp>
+#include <SFML/System/Time.hpp>
+#include <string>
+#include <vector>
+#include <set>
+
+
+namespace sf
+{
+class Sound;
+class InputSoundFile;
+class InputStream;
+
+////////////////////////////////////////////////////////////
+/// \brief Storage for audio samples defining a sound
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundBuffer : AlResource
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer(const SoundBuffer& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~SoundBuffer();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the sound buffer from a file
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param filename Path of the sound file to load
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromMemory, loadFromStream, loadFromSamples, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromFile(const std::string& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the sound buffer from a file in memory
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromStream, loadFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the sound buffer from a custom stream
+    ///
+    /// See the documentation of sf::InputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the sound buffer from an array of audio samples
+    ///
+    /// The assumed format of the audio samples is 16 bits signed integer
+    /// (sf::Int16).
+    ///
+    /// \param samples      Pointer to the array of samples in memory
+    /// \param sampleCount  Number of samples in the array
+    /// \param channelCount Number of channels (1 = mono, 2 = stereo, ...)
+    /// \param sampleRate   Sample rate (number of samples to play per second)
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromSamples(const Int16* samples, Uint64 sampleCount, unsigned int channelCount, unsigned int sampleRate);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Save the sound buffer to an audio file
+    ///
+    /// See the documentation of sf::OutputSoundFile for the list
+    /// of supported formats.
+    ///
+    /// \param filename Path of the sound file to write
+    ///
+    /// \return True if saving succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    bool saveToFile(const std::string& filename) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the array of audio samples stored in the buffer
+    ///
+    /// The format of the returned samples is 16 bits signed integer
+    /// (sf::Int16). The total number of samples in this array
+    /// is given by the getSampleCount() function.
+    ///
+    /// \return Read-only pointer to the array of sound samples
+    ///
+    /// \see getSampleCount
+    ///
+    ////////////////////////////////////////////////////////////
+    const Int16* getSamples() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the number of samples stored in the buffer
+    ///
+    /// The array of samples can be accessed with the getSamples()
+    /// function.
+    ///
+    /// \return Number of samples
+    ///
+    /// \see getSamples
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint64 getSampleCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the sample rate of the sound
+    ///
+    /// The sample rate is the number of samples played per second.
+    /// The higher, the better the quality (for example, 44100
+    /// samples/s is CD quality).
+    ///
+    /// \return Sample rate (number of samples per second)
+    ///
+    /// \see getChannelCount, getDuration
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getSampleRate() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the number of channels used by the sound
+    ///
+    /// If the sound is mono then the number of channels will
+    /// be 1, 2 for stereo, etc.
+    ///
+    /// \return Number of channels
+    ///
+    /// \see getSampleRate, getDuration
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getChannelCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the total duration of the sound
+    ///
+    /// \return Sound duration
+    ///
+    /// \see getSampleRate, getChannelCount
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getDuration() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundBuffer& operator =(const SoundBuffer& right);
+
+private:
+
+    friend class Sound;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Initialize the internal state after loading a new sound
+    ///
+    /// \param file Sound file providing access to the new loaded sound
+    ///
+    /// \return True on successful initialization, false on failure
+    ///
+    ////////////////////////////////////////////////////////////
+    bool initialize(InputSoundFile& file);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the internal buffer with the cached audio samples
+    ///
+    /// \param channelCount Number of channels
+    /// \param sampleRate   Sample rate (number of samples per second)
+    ///
+    /// \return True on success, false if any error happened
+    ///
+    ////////////////////////////////////////////////////////////
+    bool update(unsigned int channelCount, unsigned int sampleRate);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Add a sound to the list of sounds that use this buffer
+    ///
+    /// \param sound Sound instance to attach
+    ///
+    ////////////////////////////////////////////////////////////
+    void attachSound(Sound* sound) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Remove a sound from the list of sounds that use this buffer
+    ///
+    /// \param sound Sound instance to detach
+    ///
+    ////////////////////////////////////////////////////////////
+    void detachSound(Sound* sound) const;
+
+    ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::set<Sound*> SoundList; ///< Set of unique sound instances
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    unsigned int       m_buffer;   ///< OpenAL buffer identifier
+    std::vector<Int16> m_samples;  ///< Samples buffer
+    Time               m_duration; ///< Sound duration
+    mutable SoundList  m_sounds;   ///< List of sounds that are using this buffer
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOUNDBUFFER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundBuffer
+/// \ingroup audio
+///
+/// A sound buffer holds the data of a sound, which is
+/// an array of audio samples. A sample is a 16 bits signed integer
+/// that defines the amplitude of the sound at a given time.
+/// The sound is then reconstituted by playing these samples at
+/// a high rate (for example, 44100 samples per second is the
+/// standard rate used for playing CDs). In short, audio samples
+/// are like texture pixels, and a sf::SoundBuffer is similar to
+/// a sf::Texture.
+///
+/// A sound buffer can be loaded from a file (see loadFromFile()
+/// for the complete list of supported formats), from memory, from
+/// a custom stream (see sf::InputStream) or directly from an array
+/// of samples. It can also be saved back to a file.
+///
+/// Sound buffers alone are not very useful: they hold the audio data
+/// but cannot be played. To do so, you need to use the sf::Sound class,
+/// which provides functions to play/pause/stop the sound as well as
+/// changing the way it is outputted (volume, pitch, 3D position, ...).
+/// This separation allows more flexibility and better performances:
+/// indeed a sf::SoundBuffer is a heavy resource, and any operation on it
+/// is slow (often too slow for real-time applications). On the other
+/// side, a sf::Sound is a lightweight object, which can use the audio data
+/// of a sound buffer and change the way it is played without actually
+/// modifying that data. Note that it is also possible to bind
+/// several sf::Sound instances to the same sf::SoundBuffer.
+///
+/// It is important to note that the sf::Sound instance doesn't
+/// copy the buffer that it uses, it only keeps a reference to it.
+/// Thus, a sf::SoundBuffer must not be destructed while it is
+/// used by a sf::Sound (i.e. never write a function that
+/// uses a local sf::SoundBuffer instance for loading a sound).
+///
+/// Usage example:
+/// \code
+/// // Declare a new sound buffer
+/// sf::SoundBuffer buffer;
+///
+/// // Load it from a file
+/// if (!buffer.loadFromFile("sound.wav"))
+/// {
+///     // error...
+/// }
+///
+/// // Create a sound source and bind it to the buffer
+/// sf::Sound sound1;
+/// sound1.setBuffer(buffer);
+///
+/// // Play the sound
+/// sound1.play();
+///
+/// // Create another sound source bound to the same buffer
+/// sf::Sound sound2;
+/// sound2.setBuffer(buffer);
+///
+/// // Play it with a higher pitch -- the first sound remains unchanged
+/// sound2.setPitch(2);
+/// sound2.play();
+/// \endcode
+///
+/// \see sf::Sound, sf::SoundBufferRecorder
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/SoundBufferRecorder.hpp
+++ b/libs/include/SFML/Audio/SoundBufferRecorder.hpp
@@ -1,0 +1,144 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUNDBUFFERRECORDER_HPP
+#define SFML_SOUNDBUFFERRECORDER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/Audio/SoundBuffer.hpp>
+#include <SFML/Audio/SoundRecorder.hpp>
+#include <vector>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Specialized SoundRecorder which stores the captured
+///        audio data into a sound buffer
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundBufferRecorder : public SoundRecorder
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~SoundBufferRecorder();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the sound buffer containing the captured audio data
+    ///
+    /// The sound buffer is valid only after the capture has ended.
+    /// This function provides a read-only access to the internal
+    /// sound buffer, but it can be copied if you need to
+    /// make any modification to it.
+    ///
+    /// \return Read-only access to the sound buffer
+    ///
+    ////////////////////////////////////////////////////////////
+    const SoundBuffer& getBuffer() const;
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Start capturing audio data
+    ///
+    /// \return True to start the capture, or false to abort it
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool onStart();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Process a new chunk of recorded samples
+    ///
+    /// \param samples     Pointer to the new chunk of recorded samples
+    /// \param sampleCount Number of samples pointed by \a samples
+    ///
+    /// \return True to continue the capture, or false to stop it
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool onProcessSamples(const Int16* samples, std::size_t sampleCount);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Stop capturing audio data
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onStop();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::vector<Int16> m_samples; ///< Temporary sample buffer to hold the recorded data
+    SoundBuffer        m_buffer;  ///< Sound buffer that will contain the recorded data
+};
+
+} // namespace sf
+
+#endif // SFML_SOUNDBUFFERRECORDER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundBufferRecorder
+/// \ingroup audio
+///
+/// sf::SoundBufferRecorder allows to access a recorded sound
+/// through a sf::SoundBuffer, so that it can be played, saved
+/// to a file, etc.
+///
+/// It has the same simple interface as its base class (start(), stop())
+/// and adds a function to retrieve the recorded sound buffer
+/// (getBuffer()).
+///
+/// As usual, don't forget to call the isAvailable() function
+/// before using this class (see sf::SoundRecorder for more details
+/// about this).
+///
+/// Usage example:
+/// \code
+/// if (sf::SoundBufferRecorder::isAvailable())
+/// {
+///     // Record some audio data
+///     sf::SoundBufferRecorder recorder;
+///     recorder.start();
+///     ...
+///     recorder.stop();
+///
+///     // Get the buffer containing the captured audio data
+///     const sf::SoundBuffer& buffer = recorder.getBuffer();
+///
+///     // Save it to a file (for example...)
+///     buffer.saveToFile("my_record.ogg");
+/// }
+/// \endcode
+///
+/// \see sf::SoundRecorder
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/SoundFileFactory.hpp
+++ b/libs/include/SFML/Audio/SoundFileFactory.hpp
@@ -1,0 +1,197 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUNDFILEFACTORY_HPP
+#define SFML_SOUNDFILEFACTORY_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <string>
+#include <vector>
+
+
+namespace sf
+{
+class InputStream;
+class SoundFileReader;
+class SoundFileWriter;
+
+////////////////////////////////////////////////////////////
+/// \brief Manages and instantiates sound file readers and writers
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundFileFactory
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Register a new reader
+    ///
+    /// \see unregisterReader
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    static void registerReader();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Unregister a reader
+    ///
+    /// \see registerReader
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    static void unregisterReader();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Register a new writer
+    ///
+    /// \see unregisterWriter
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    static void registerWriter();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Unregister a writer
+    ///
+    /// \see registerWriter
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    static void unregisterWriter();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Instantiate the right reader for the given file on disk
+    ///
+    /// It's up to the caller to release the returned reader
+    ///
+    /// \param filename Path of the sound file
+    ///
+    /// \return A new sound file reader that can read the given file, or null if no reader can handle it
+    ///
+    /// \see createReaderFromMemory, createReaderFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    static SoundFileReader* createReaderFromFilename(const std::string& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Instantiate the right codec for the given file in memory
+    ///
+    /// It's up to the caller to release the returned reader
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Total size of the file data, in bytes
+    ///
+    /// \return A new sound file codec that can read the given file, or null if no codec can handle it
+    ///
+    /// \see createReaderFromFilename, createReaderFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    static SoundFileReader* createReaderFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Instantiate the right codec for the given file in stream
+    ///
+    /// It's up to the caller to release the returned reader
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return A new sound file codec that can read the given file, or null if no codec can handle it
+    ///
+    /// \see createReaderFromFilename, createReaderFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    static SoundFileReader* createReaderFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Instantiate the right writer for the given file on disk
+    ///
+    /// It's up to the caller to release the returned writer
+    ///
+    /// \param filename Path of the sound file
+    ///
+    /// \return A new sound file writer that can write given file, or null if no writer can handle it
+    ///
+    ////////////////////////////////////////////////////////////
+    static SoundFileWriter* createWriterFromFilename(const std::string& filename);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    struct ReaderFactory
+    {
+        bool (*check)(InputStream&);
+        SoundFileReader* (*create)();
+    };
+    typedef std::vector<ReaderFactory> ReaderFactoryArray;
+
+    struct WriterFactory
+    {
+        bool (*check)(const std::string&);
+        SoundFileWriter* (*create)();
+    };
+    typedef std::vector<WriterFactory> WriterFactoryArray;
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static ReaderFactoryArray s_readers; ///< List of all registered readers
+    static WriterFactoryArray s_writers; ///< List of all registered writers
+};
+
+} // namespace sf
+
+#include <SFML/Audio/SoundFileFactory.inl>
+
+#endif // SFML_SOUNDFILEFACTORY_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundFileFactory
+/// \ingroup audio
+///
+/// This class is where all the sound file readers and writers are
+/// registered. You should normally only need to use its registration
+/// and unregistration functions; readers/writers creation and manipulation
+/// are wrapped into the higher-level classes sf::InputSoundFile and
+/// sf::OutputSoundFile.
+///
+/// To register a new reader (writer) use the sf::SoundFileFactory::registerReader
+/// (registerWriter) static function. You don't have to call the unregisterReader
+/// (unregisterWriter) function, unless you want to unregister a format before your
+/// application ends (typically, when a plugin is unloaded).
+///
+/// Usage example:
+/// \code
+/// sf::SoundFileFactory::registerReader<MySoundFileReader>();
+/// sf::SoundFileFactory::registerWriter<MySoundFileWriter>();
+/// \endcode
+///
+/// \see sf::InputSoundFile, sf::OutputSoundFile, sf::SoundFileReader, sf::SoundFileWriter
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/SoundFileFactory.inl
+++ b/libs/include/SFML/Audio/SoundFileFactory.inl
@@ -1,0 +1,100 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
+
+namespace sf
+{
+namespace priv
+{
+    template <typename T> SoundFileReader* createReader() {return new T;}
+    template <typename T> SoundFileWriter* createWriter() {return new T;}
+}
+
+////////////////////////////////////////////////////////////
+template <typename T>
+void SoundFileFactory::registerReader()
+{
+    // Make sure the same class won't be registered twice
+    unregisterReader<T>();
+
+    // Create a new factory with the functions provided by the class
+    ReaderFactory factory;
+    factory.check = &T::check;
+    factory.create = &priv::createReader<T>;
+
+    // Add it
+    s_readers.push_back(factory);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+void SoundFileFactory::unregisterReader()
+{
+    // Remove the instance(s) of the reader from the array of factories
+    for (ReaderFactoryArray::iterator it = s_readers.begin(); it != s_readers.end(); )
+    {
+        if (it->create == &priv::createReader<T>)
+            it = s_readers.erase(it);
+        else
+            ++it;
+    }
+}
+
+////////////////////////////////////////////////////////////
+template <typename T>
+void SoundFileFactory::registerWriter()
+{
+    // Make sure the same class won't be registered twice
+    unregisterWriter<T>();
+
+    // Create a new factory with the functions provided by the class
+    WriterFactory factory;
+    factory.check = &T::check;
+    factory.create = &priv::createWriter<T>;
+
+    // Add it
+    s_writers.push_back(factory);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+void SoundFileFactory::unregisterWriter()
+{
+    // Remove the instance(s) of the writer from the array of factories
+    for (WriterFactoryArray::iterator it = s_writers.begin(); it != s_writers.end(); )
+    {
+        if (it->create == &priv::createWriter<T>)
+            it = s_writers.erase(it);
+        else
+            ++it;
+    }
+}
+
+} // namespace sf

--- a/libs/include/SFML/Audio/SoundFileReader.hpp
+++ b/libs/include/SFML/Audio/SoundFileReader.hpp
@@ -1,0 +1,165 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUNDFILEREADER_HPP
+#define SFML_SOUNDFILEREADER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <string>
+
+
+namespace sf
+{
+class InputStream;
+
+////////////////////////////////////////////////////////////
+/// \brief Abstract base class for sound file decoding
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundFileReader
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Structure holding the audio properties of a sound file
+    ///
+    ////////////////////////////////////////////////////////////
+    struct Info
+    {
+        Uint64       sampleCount;  ///< Total number of samples in the file
+        unsigned int channelCount; ///< Number of channels of the sound
+        unsigned int sampleRate;   ///< Samples rate of the sound, in samples per second
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Virtual destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~SoundFileReader() {}
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a sound file for reading
+    ///
+    /// The provided stream reference is valid as long as the
+    /// SoundFileReader is alive, so it is safe to use/store it
+    /// during the whole lifetime of the reader.
+    ///
+    /// \param stream Source stream to read from
+    /// \param info   Structure to fill with the properties of the loaded sound
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool open(InputStream& stream, Info& info) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current read position to the given sample offset
+    ///
+    /// The sample offset takes the channels into account.
+    /// If you have a time offset instead, you can easily find
+    /// the corresponding sample offset with the following formula:
+    /// `timeInSeconds * sampleRate * channelCount`
+    /// If the given offset exceeds to total number of samples,
+    /// this function must jump to the end of the file.
+    ///
+    /// \param sampleOffset Index of the sample to jump to, relative to the beginning
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void seek(Uint64 sampleOffset) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Read audio samples from the open file
+    ///
+    /// \param samples  Pointer to the sample array to fill
+    /// \param maxCount Maximum number of samples to read
+    ///
+    /// \return Number of samples actually read (may be less than \a maxCount)
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Uint64 read(Int16* samples, Uint64 maxCount) = 0;
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOUNDFILEREADER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundFileReader
+/// \ingroup audio
+///
+/// This class allows users to read audio file formats not natively
+/// supported by SFML, and thus extend the set of supported readable
+/// audio formats.
+///
+/// A valid sound file reader must override the open, seek and write functions,
+/// as well as providing a static check function; the latter is used by
+/// SFML to find a suitable writer for a given input file.
+///
+/// To register a new reader, use the sf::SoundFileFactory::registerReader
+/// template function.
+///
+/// Usage example:
+/// \code
+/// class MySoundFileReader : public sf::SoundFileReader
+/// {
+/// public:
+///
+///     static bool check(sf::InputStream& stream)
+///     {
+///         // typically, read the first few header bytes and check fields that identify the format
+///         // return true if the reader can handle the format
+///     }
+///
+///     virtual bool open(sf::InputStream& stream, Info& info)
+///     {
+///         // read the sound file header and fill the sound attributes
+///         // (channel count, sample count and sample rate)
+///         // return true on success
+///     }
+///
+///     virtual void seek(sf::Uint64 sampleOffset)
+///     {
+///         // advance to the sampleOffset-th sample from the beginning of the sound
+///     }
+///
+///     virtual sf::Uint64 read(sf::Int16* samples, sf::Uint64 maxCount)
+///     {
+///         // read up to 'maxCount' samples into the 'samples' array,
+///         // convert them (for example from normalized float) if they are not stored
+///         // as 16-bits signed integers in the file
+///         // return the actual number of samples read
+///     }
+/// };
+///
+/// sf::SoundFileFactory::registerReader<MySoundFileReader>();
+/// \endcode
+///
+/// \see sf::InputSoundFile, sf::SoundFileFactory, sf::SoundFileWriter
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/SoundFileWriter.hpp
+++ b/libs/include/SFML/Audio/SoundFileWriter.hpp
@@ -1,0 +1,125 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUNDFILEWRITER_HPP
+#define SFML_SOUNDFILEWRITER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <string>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Abstract base class for sound file encoding
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundFileWriter
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Virtual destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~SoundFileWriter() {}
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open a sound file for writing
+    ///
+    /// \param filename     Path of the file to open
+    /// \param sampleRate   Sample rate of the sound
+    /// \param channelCount Number of channels of the sound
+    ///
+    /// \return True if the file was successfully opened
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool open(const std::string& filename, unsigned int sampleRate, unsigned int channelCount) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Write audio samples to the open file
+    ///
+    /// \param samples Pointer to the sample array to write
+    /// \param count   Number of samples to write
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void write(const Int16* samples, Uint64 count) = 0;
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOUNDFILEWRITER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundFileWriter
+/// \ingroup audio
+///
+/// This class allows users to write audio file formats not natively
+/// supported by SFML, and thus extend the set of supported writable
+/// audio formats.
+///
+/// A valid sound file writer must override the open and write functions,
+/// as well as providing a static check function; the latter is used by
+/// SFML to find a suitable writer for a given filename.
+///
+/// To register a new writer, use the sf::SoundFileFactory::registerWriter
+/// template function.
+///
+/// Usage example:
+/// \code
+/// class MySoundFileWriter : public sf::SoundFileWriter
+/// {
+/// public:
+///
+///     static bool check(const std::string& filename)
+///     {
+///         // typically, check the extension
+///         // return true if the writer can handle the format
+///     }
+///
+///     virtual bool open(const std::string& filename, unsigned int sampleRate, unsigned int channelCount)
+///     {
+///         // open the file 'filename' for writing,
+///         // write the given sample rate and channel count to the file header
+///         // return true on success
+///     }
+///
+///     virtual void write(const sf::Int16* samples, sf::Uint64 count)
+///     {
+///         // write 'count' samples stored at address 'samples',
+///         // convert them (for example to normalized float) if the format requires it
+///     }
+/// };
+///
+/// sf::SoundFileFactory::registerWriter<MySoundFileWriter>();
+/// \endcode
+///
+/// \see sf::OutputSoundFile, sf::SoundFileFactory, sf::SoundFileReader
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/SoundRecorder.hpp
+++ b/libs/include/SFML/Audio/SoundRecorder.hpp
@@ -1,0 +1,408 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUNDRECORDER_HPP
+#define SFML_SOUNDRECORDER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/Audio/AlResource.hpp>
+#include <SFML/System/Thread.hpp>
+#include <SFML/System/Time.hpp>
+#include <vector>
+#include <string>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Abstract base class for capturing sound data
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundRecorder : AlResource
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~SoundRecorder();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Start the capture
+    ///
+    /// The \a sampleRate parameter defines the number of audio samples
+    /// captured per second. The higher, the better the quality
+    /// (for example, 44100 samples/sec is CD quality).
+    /// This function uses its own thread so that it doesn't block
+    /// the rest of the program while the capture runs.
+    /// Please note that only one capture can happen at the same time.
+    /// You can select which capture device will be used, by passing
+    /// the name to the setDevice() method. If none was selected
+    /// before, the default capture device will be used. You can get a
+    /// list of the names of all available capture devices by calling
+    /// getAvailableDevices().
+    ///
+    /// \param sampleRate Desired capture rate, in number of samples per second
+    ///
+    /// \return True, if start of capture was successful
+    ///
+    /// \see stop, getAvailableDevices
+    ///
+    ////////////////////////////////////////////////////////////
+    bool start(unsigned int sampleRate = 44100);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Stop the capture
+    ///
+    /// \see start
+    ///
+    ////////////////////////////////////////////////////////////
+    void stop();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the sample rate
+    ///
+    /// The sample rate defines the number of audio samples
+    /// captured per second. The higher, the better the quality
+    /// (for example, 44100 samples/sec is CD quality).
+    ///
+    /// \return Sample rate, in samples per second
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getSampleRate() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a list of the names of all available audio capture devices
+    ///
+    /// This function returns a vector of strings, containing
+    /// the names of all available audio capture devices.
+    ///
+    /// \return A vector of strings containing the names
+    ///
+    ////////////////////////////////////////////////////////////
+    static std::vector<std::string> getAvailableDevices();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the name of the default audio capture device
+    ///
+    /// This function returns the name of the default audio
+    /// capture device. If none is available, an empty string
+    /// is returned.
+    ///
+    /// \return The name of the default audio capture device
+    ///
+    ////////////////////////////////////////////////////////////
+    static std::string getDefaultDevice();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the audio capture device
+    ///
+    /// This function sets the audio capture device to the device
+    /// with the given \a name. It can be called on the fly (i.e:
+    /// while recording). If you do so while recording and
+    /// opening the device fails, it stops the recording.
+    ///
+    /// \param name The name of the audio capture device
+    ///
+    /// \return True, if it was able to set the requested device
+    ///
+    /// \see getAvailableDevices, getDefaultDevice
+    ///
+    ////////////////////////////////////////////////////////////
+    bool setDevice(const std::string& name);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the name of the current audio capture device
+    ///
+    /// \return The name of the current audio capture device
+    ///
+    ////////////////////////////////////////////////////////////
+    const std::string& getDevice() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the channel count of the audio capture device
+    ///
+    /// This method allows you to specify the number of channels
+    /// used for recording. Currently only 16-bit mono and
+    /// 16-bit stereo are supported.
+    ///
+    /// \param channelCount Number of channels. Currently only
+    ///                     mono (1) and stereo (2) are supported.
+    ///
+    /// \see getChannelCount
+    ///
+    ////////////////////////////////////////////////////////////
+    void setChannelCount(unsigned int channelCount);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the number of channels used by this recorder
+    ///
+    /// Currently only mono and stereo are supported, so the
+    /// value is either 1 (for mono) or 2 (for stereo).
+    ///
+    /// \return Number of channels
+    ///
+    /// \see setChannelCount
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getChannelCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if the system supports audio capture
+    ///
+    /// This function should always be called before using
+    /// the audio capture features. If it returns false, then
+    /// any attempt to use sf::SoundRecorder or one of its derived
+    /// classes will fail.
+    ///
+    /// \return True if audio capture is supported, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isAvailable();
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor is only meant to be called by derived classes.
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundRecorder();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the processing interval
+    ///
+    /// The processing interval controls the period
+    /// between calls to the onProcessSamples function. You may
+    /// want to use a small interval if you want to process the
+    /// recorded data in real time, for example.
+    ///
+    /// Note: this is only a hint, the actual period may vary.
+    /// So don't rely on this parameter to implement precise timing.
+    ///
+    /// The default processing interval is 100 ms.
+    ///
+    /// \param interval Processing interval
+    ///
+    ////////////////////////////////////////////////////////////
+    void setProcessingInterval(Time interval);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Start capturing audio data
+    ///
+    /// This virtual function may be overridden by a derived class
+    /// if something has to be done every time a new capture
+    /// starts. If not, this function can be ignored; the default
+    /// implementation does nothing.
+    ///
+    /// \return True to start the capture, or false to abort it
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool onStart();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Process a new chunk of recorded samples
+    ///
+    /// This virtual function is called every time a new chunk of
+    /// recorded data is available. The derived class can then do
+    /// whatever it wants with it (storing it, playing it, sending
+    /// it over the network, etc.).
+    ///
+    /// \param samples     Pointer to the new chunk of recorded samples
+    /// \param sampleCount Number of samples pointed by \a samples
+    ///
+    /// \return True to continue the capture, or false to stop it
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool onProcessSamples(const Int16* samples, std::size_t sampleCount) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Stop capturing audio data
+    ///
+    /// This virtual function may be overridden by a derived class
+    /// if something has to be done every time the capture
+    /// ends. If not, this function can be ignored; the default
+    /// implementation does nothing.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onStop();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Function called as the entry point of the thread
+    ///
+    /// This function starts the recording loop, and returns
+    /// only when the capture is stopped.
+    ///
+    ////////////////////////////////////////////////////////////
+    void record();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the new available audio samples and process them
+    ///
+    /// This function is called continuously during the
+    /// capture loop. It retrieves the captured samples and
+    /// forwards them to the derived class.
+    ///
+    ////////////////////////////////////////////////////////////
+    void processCapturedSamples();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clean up the recorder's internal resources
+    ///
+    /// This function is called when the capture stops.
+    ///
+    ////////////////////////////////////////////////////////////
+    void cleanup();
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Thread             m_thread;             ///< Thread running the background recording task
+    std::vector<Int16> m_samples;            ///< Buffer to store captured samples
+    unsigned int       m_sampleRate;         ///< Sample rate
+    Time               m_processingInterval; ///< Time period between calls to onProcessSamples
+    bool               m_isCapturing;        ///< Capturing state
+    std::string        m_deviceName;         ///< Name of the audio capture device
+    unsigned int       m_channelCount;       ///< Number of recording channels
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOUNDRECORDER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundRecorder
+/// \ingroup audio
+///
+/// sf::SoundBuffer provides a simple interface to access
+/// the audio recording capabilities of the computer
+/// (the microphone). As an abstract base class, it only cares
+/// about capturing sound samples, the task of making something
+/// useful with them is left to the derived class. Note that
+/// SFML provides a built-in specialization for saving the
+/// captured data to a sound buffer (see sf::SoundBufferRecorder).
+///
+/// A derived class has only one virtual function to override:
+/// \li onProcessSamples provides the new chunks of audio samples while the capture happens
+///
+/// Moreover, two additional virtual functions can be overridden
+/// as well if necessary:
+/// \li onStart is called before the capture happens, to perform custom initializations
+/// \li onStop is called after the capture ends, to perform custom cleanup
+///
+/// A derived class can also control the frequency of the onProcessSamples
+/// calls, with the setProcessingInterval protected function. The default
+/// interval is chosen so that recording thread doesn't consume too much
+/// CPU, but it can be changed to a smaller value if you need to process
+/// the recorded data in real time, for example.
+///
+/// The audio capture feature may not be supported or activated
+/// on every platform, thus it is recommended to check its
+/// availability with the isAvailable() function. If it returns
+/// false, then any attempt to use an audio recorder will fail.
+///
+/// If you have multiple sound input devices connected to your
+/// computer (for example: microphone, external soundcard, webcam mic, ...)
+/// you can get a list of all available devices through the
+/// getAvailableDevices() function. You can then select a device
+/// by calling setDevice() with the appropriate device. Otherwise
+/// the default capturing device will be used.
+///
+/// By default the recording is in 16-bit mono. Using the
+/// setChannelCount method you can change the number of channels
+/// used by the audio capture device to record. Note that you
+/// have to decide whether you want to record in mono or stereo
+/// before starting the recording.
+///
+/// It is important to note that the audio capture happens in a
+/// separate thread, so that it doesn't block the rest of the
+/// program. In particular, the onProcessSamples virtual function
+/// (but not onStart and not onStop) will be called
+/// from this separate thread. It is important to keep this in
+/// mind, because you may have to take care of synchronization
+/// issues if you share data between threads.
+/// Another thing to bear in mind is that you must call stop()
+/// in the destructor of your derived class, so that the recording
+/// thread finishes before your object is destroyed.
+///
+/// Usage example:
+/// \code
+/// class CustomRecorder : public sf::SoundRecorder
+/// {
+///     ~CustomRecorder()
+///     {
+///         // Make sure to stop the recording thread
+///         stop();
+///     }
+///
+///     virtual bool onStart() // optional
+///     {
+///         // Initialize whatever has to be done before the capture starts
+///         ...
+///
+///         // Return true to start playing
+///         return true;
+///     }
+///
+///     virtual bool onProcessSamples(const Int16* samples, std::size_t sampleCount)
+///     {
+///         // Do something with the new chunk of samples (store them, send them, ...)
+///         ...
+///
+///         // Return true to continue playing
+///         return true;
+///     }
+///
+///     virtual void onStop() // optional
+///     {
+///         // Clean up whatever has to be done after the capture ends
+///         ...
+///     }
+/// }
+///
+/// // Usage
+/// if (CustomRecorder::isAvailable())
+/// {
+///     CustomRecorder recorder;
+///
+///     if (!recorder.start())
+///         return -1;
+///
+///     ...
+///     recorder.stop();
+/// }
+/// \endcode
+///
+/// \see sf::SoundBufferRecorder
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/SoundSource.hpp
+++ b/libs/include/SFML/Audio/SoundSource.hpp
@@ -1,0 +1,332 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUNDSOURCE_HPP
+#define SFML_SOUNDSOURCE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/Audio/AlResource.hpp>
+#include <SFML/System/Vector3.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Base class defining a sound's properties
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundSource : AlResource
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enumeration of the sound source states
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Status
+    {
+        Stopped, ///< Sound is not playing
+        Paused,  ///< Sound is paused
+        Playing  ///< Sound is playing
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundSource(const SoundSource& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~SoundSource();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the pitch of the sound
+    ///
+    /// The pitch represents the perceived fundamental frequency
+    /// of a sound; thus you can make a sound more acute or grave
+    /// by changing its pitch. A side effect of changing the pitch
+    /// is to modify the playing speed of the sound as well.
+    /// The default value for the pitch is 1.
+    ///
+    /// \param pitch New pitch to apply to the sound
+    ///
+    /// \see getPitch
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPitch(float pitch);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the volume of the sound
+    ///
+    /// The volume is a value between 0 (mute) and 100 (full volume).
+    /// The default value for the volume is 100.
+    ///
+    /// \param volume Volume of the sound
+    ///
+    /// \see getVolume
+    ///
+    ////////////////////////////////////////////////////////////
+    void setVolume(float volume);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the 3D position of the sound in the audio scene
+    ///
+    /// Only sounds with one channel (mono sounds) can be
+    /// spatialized.
+    /// The default position of a sound is (0, 0, 0).
+    ///
+    /// \param x X coordinate of the position of the sound in the scene
+    /// \param y Y coordinate of the position of the sound in the scene
+    /// \param z Z coordinate of the position of the sound in the scene
+    ///
+    /// \see getPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPosition(float x, float y, float z);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the 3D position of the sound in the audio scene
+    ///
+    /// Only sounds with one channel (mono sounds) can be
+    /// spatialized.
+    /// The default position of a sound is (0, 0, 0).
+    ///
+    /// \param position Position of the sound in the scene
+    ///
+    /// \see getPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPosition(const Vector3f& position);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Make the sound's position relative to the listener or absolute
+    ///
+    /// Making a sound relative to the listener will ensure that it will always
+    /// be played the same way regardless of the position of the listener.
+    /// This can be useful for non-spatialized sounds, sounds that are
+    /// produced by the listener, or sounds attached to it.
+    /// The default value is false (position is absolute).
+    ///
+    /// \param relative True to set the position relative, false to set it absolute
+    ///
+    /// \see isRelativeToListener
+    ///
+    ////////////////////////////////////////////////////////////
+    void setRelativeToListener(bool relative);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the minimum distance of the sound
+    ///
+    /// The "minimum distance" of a sound is the maximum
+    /// distance at which it is heard at its maximum volume. Further
+    /// than the minimum distance, it will start to fade out according
+    /// to its attenuation factor. A value of 0 ("inside the head
+    /// of the listener") is an invalid value and is forbidden.
+    /// The default value of the minimum distance is 1.
+    ///
+    /// \param distance New minimum distance of the sound
+    ///
+    /// \see getMinDistance, setAttenuation
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMinDistance(float distance);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the attenuation factor of the sound
+    ///
+    /// The attenuation is a multiplicative factor which makes
+    /// the sound more or less loud according to its distance
+    /// from the listener. An attenuation of 0 will produce a
+    /// non-attenuated sound, i.e. its volume will always be the same
+    /// whether it is heard from near or from far. On the other hand,
+    /// an attenuation value such as 100 will make the sound fade out
+    /// very quickly as it gets further from the listener.
+    /// The default value of the attenuation is 1.
+    ///
+    /// \param attenuation New attenuation factor of the sound
+    ///
+    /// \see getAttenuation, setMinDistance
+    ///
+    ////////////////////////////////////////////////////////////
+    void setAttenuation(float attenuation);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the pitch of the sound
+    ///
+    /// \return Pitch of the sound
+    ///
+    /// \see setPitch
+    ///
+    ////////////////////////////////////////////////////////////
+    float getPitch() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the volume of the sound
+    ///
+    /// \return Volume of the sound, in the range [0, 100]
+    ///
+    /// \see setVolume
+    ///
+    ////////////////////////////////////////////////////////////
+    float getVolume() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the 3D position of the sound in the audio scene
+    ///
+    /// \return Position of the sound
+    ///
+    /// \see setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector3f getPosition() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the sound's position is relative to the
+    ///        listener or is absolute
+    ///
+    /// \return True if the position is relative, false if it's absolute
+    ///
+    /// \see setRelativeToListener
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isRelativeToListener() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the minimum distance of the sound
+    ///
+    /// \return Minimum distance of the sound
+    ///
+    /// \see setMinDistance, getAttenuation
+    ///
+    ////////////////////////////////////////////////////////////
+    float getMinDistance() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the attenuation factor of the sound
+    ///
+    /// \return Attenuation factor of the sound
+    ///
+    /// \see setAttenuation, getMinDistance
+    ///
+    ////////////////////////////////////////////////////////////
+    float getAttenuation() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundSource& operator =(const SoundSource& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Start or resume playing the sound source
+    ///
+    /// This function starts the source if it was stopped, resumes
+    /// it if it was paused, and restarts it from the beginning if
+    /// it was already playing.
+    ///
+    /// \see pause, stop
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void play() = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Pause the sound source
+    ///
+    /// This function pauses the source if it was playing,
+    /// otherwise (source already paused or stopped) it has no effect.
+    ///
+    /// \see play, stop
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void pause() = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Stop playing the sound source
+    ///
+    /// This function stops the source if it was playing or paused,
+    /// and does nothing if it was already stopped.
+    /// It also resets the playing position (unlike pause()).
+    ///
+    /// \see play, pause
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void stop() = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current status of the sound (stopped, paused, playing)
+    ///
+    /// \return Current status of the sound
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Status getStatus() const;
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor is meant to be called by derived classes only.
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundSource();
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    unsigned int m_source; ///< OpenAL source identifier
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOUNDSOURCE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundSource
+/// \ingroup audio
+///
+/// sf::SoundSource is not meant to be used directly, it
+/// only serves as a common base for all audio objects
+/// that can live in the audio environment.
+///
+/// It defines several properties for the sound: pitch,
+/// volume, position, attenuation, etc. All of them can be
+/// changed at any time with no impact on performances.
+///
+/// \see sf::Sound, sf::SoundStream
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Audio/SoundStream.hpp
+++ b/libs/include/SFML/Audio/SoundStream.hpp
@@ -1,0 +1,405 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOUNDSTREAM_HPP
+#define SFML_SOUNDSTREAM_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Audio/Export.hpp>
+#include <SFML/Audio/SoundSource.hpp>
+#include <SFML/System/Thread.hpp>
+#include <SFML/System/Time.hpp>
+#include <SFML/System/Mutex.hpp>
+#include <cstdlib>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Abstract base class for streamed audio sources
+///
+////////////////////////////////////////////////////////////
+class SFML_AUDIO_API SoundStream : public SoundSource
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Structure defining a chunk of audio data to stream
+    ///
+    ////////////////////////////////////////////////////////////
+    struct Chunk
+    {
+        const Int16* samples;     ///< Pointer to the audio samples
+        std::size_t  sampleCount; ///< Number of samples pointed by Samples
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~SoundStream();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Start or resume playing the audio stream
+    ///
+    /// This function starts the stream if it was stopped, resumes
+    /// it if it was paused, and restarts it from the beginning if
+    /// it was already playing.
+    /// This function uses its own thread so that it doesn't block
+    /// the rest of the program while the stream is played.
+    ///
+    /// \see pause, stop
+    ///
+    ////////////////////////////////////////////////////////////
+    void play();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Pause the audio stream
+    ///
+    /// This function pauses the stream if it was playing,
+    /// otherwise (stream already paused or stopped) it has no effect.
+    ///
+    /// \see play, stop
+    ///
+    ////////////////////////////////////////////////////////////
+    void pause();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Stop playing the audio stream
+    ///
+    /// This function stops the stream if it was playing or paused,
+    /// and does nothing if it was already stopped.
+    /// It also resets the playing position (unlike pause()).
+    ///
+    /// \see play, pause
+    ///
+    ////////////////////////////////////////////////////////////
+    void stop();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the number of channels of the stream
+    ///
+    /// 1 channel means a mono sound, 2 means stereo, etc.
+    ///
+    /// \return Number of channels
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getChannelCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the stream sample rate of the stream
+    ///
+    /// The sample rate is the number of audio samples played per
+    /// second. The higher, the better the quality.
+    ///
+    /// \return Sample rate, in number of samples per second
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getSampleRate() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current status of the stream (stopped, paused, playing)
+    ///
+    /// \return Current status
+    ///
+    ////////////////////////////////////////////////////////////
+    Status getStatus() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current playing position of the stream
+    ///
+    /// The playing position can be changed when the stream is
+    /// either paused or playing. Changing the playing position
+    /// when the stream is stopped has no effect, since playing
+    /// the stream would reset its position.
+    ///
+    /// \param timeOffset New playing position, from the beginning of the stream
+    ///
+    /// \see getPlayingOffset
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPlayingOffset(Time timeOffset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current playing position of the stream
+    ///
+    /// \return Current playing position, from the beginning of the stream
+    ///
+    /// \see setPlayingOffset
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getPlayingOffset() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set whether or not the stream should loop after reaching the end
+    ///
+    /// If set, the stream will restart from beginning after
+    /// reaching the end and so on, until it is stopped or
+    /// setLoop(false) is called.
+    /// The default looping state for streams is false.
+    ///
+    /// \param loop True to play in loop, false to play once
+    ///
+    /// \see getLoop
+    ///
+    ////////////////////////////////////////////////////////////
+    void setLoop(bool loop);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the stream is in loop mode
+    ///
+    /// \return True if the stream is looping, false otherwise
+    ///
+    /// \see setLoop
+    ///
+    ////////////////////////////////////////////////////////////
+    bool getLoop() const;
+
+protected:
+
+    enum
+    {
+        NoLoop = -1 ///< "Invalid" endSeeks value, telling us to continue uninterrupted
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor is only meant to be called by derived classes.
+    ///
+    ////////////////////////////////////////////////////////////
+    SoundStream();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Define the audio stream parameters
+    ///
+    /// This function must be called by derived classes as soon
+    /// as they know the audio settings of the stream to play.
+    /// Any attempt to manipulate the stream (play(), ...) before
+    /// calling this function will fail.
+    /// It can be called multiple times if the settings of the
+    /// audio stream change, but only when the stream is stopped.
+    ///
+    /// \param channelCount Number of channels of the stream
+    /// \param sampleRate   Sample rate, in samples per second
+    ///
+    ////////////////////////////////////////////////////////////
+    void initialize(unsigned int channelCount, unsigned int sampleRate);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Request a new chunk of audio samples from the stream source
+    ///
+    /// This function must be overridden by derived classes to provide
+    /// the audio samples to play. It is called continuously by the
+    /// streaming loop, in a separate thread.
+    /// The source can choose to stop the streaming loop at any time, by
+    /// returning false to the caller.
+    /// If you return true (i.e. continue streaming) it is important that
+    /// the returned array of samples is not empty; this would stop the stream
+    /// due to an internal limitation.
+    ///
+    /// \param data Chunk of data to fill
+    ///
+    /// \return True to continue playback, false to stop
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool onGetData(Chunk& data) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current playing position in the stream source
+    ///
+    /// This function must be overridden by derived classes to
+    /// allow random seeking into the stream source.
+    ///
+    /// \param timeOffset New playing position, relative to the beginning of the stream
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onSeek(Time timeOffset) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current playing position in the stream source to the beginning of the loop
+    ///
+    /// This function can be overridden by derived classes to
+    /// allow implementation of custom loop points. Otherwise,
+    /// it just calls onSeek(Time::Zero) and returns 0.
+    ///
+    /// \return The seek position after looping (or -1 if there's no loop)
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 onLoop();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Function called as the entry point of the thread
+    ///
+    /// This function starts the streaming loop, and returns
+    /// only when the sound is stopped.
+    ///
+    ////////////////////////////////////////////////////////////
+    void streamData();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Fill a new buffer with audio samples, and append
+    ///        it to the playing queue
+    ///
+    /// This function is called as soon as a buffer has been fully
+    /// consumed; it fills it again and inserts it back into the
+    /// playing queue.
+    ///
+    /// \param bufferNum Number of the buffer to fill (in [0, BufferCount])
+    /// \param immediateLoop Treat empty buffers as spent, and act on loops immediately
+    ///
+    /// \return True if the stream source has requested to stop, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool fillAndPushBuffer(unsigned int bufferNum, bool immediateLoop = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Fill the audio buffers and put them all into the playing queue
+    ///
+    /// This function is called when playing starts and the
+    /// playing queue is empty.
+    ///
+    /// \return True if the derived class has requested to stop, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool fillQueue();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clear all the audio buffers and empty the playing queue
+    ///
+    /// This function is called when the stream is stopped.
+    ///
+    ////////////////////////////////////////////////////////////
+    void clearQueue();
+
+    enum
+    {
+        BufferCount = 3,    ///< Number of audio buffers used by the streaming loop
+        BufferRetries = 2   ///< Number of retries (excluding initial try) for onGetData()
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Thread        m_thread;                   ///< Thread running the background tasks
+    mutable Mutex m_threadMutex;              ///< Thread mutex
+    Status        m_threadStartState;         ///< State the thread starts in (Playing, Paused, Stopped)
+    bool          m_isStreaming;              ///< Streaming state (true = playing, false = stopped)
+    unsigned int  m_buffers[BufferCount];     ///< Sound buffers used to store temporary audio data
+    unsigned int  m_channelCount;             ///< Number of channels (1 = mono, 2 = stereo, ...)
+    unsigned int  m_sampleRate;               ///< Frequency (samples / second)
+    Uint32        m_format;                   ///< Format of the internal sound buffers
+    bool          m_loop;                     ///< Loop flag (true to loop, false to play once)
+    Uint64        m_samplesProcessed;         ///< Number of buffers processed since beginning of the stream
+    Int64         m_bufferSeeks[BufferCount]; ///< If buffer is an "end buffer", holds next seek position, else NoLoop. For play offset calculation.
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOUNDSTREAM_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SoundStream
+/// \ingroup audio
+///
+/// Unlike audio buffers (see sf::SoundBuffer), audio streams
+/// are never completely loaded in memory. Instead, the audio
+/// data is acquired continuously while the stream is playing.
+/// This behavior allows to play a sound with no loading delay,
+/// and keeps the memory consumption very low.
+///
+/// Sound sources that need to be streamed are usually big files
+/// (compressed audio musics that would eat hundreds of MB in memory)
+/// or files that would take a lot of time to be received
+/// (sounds played over the network).
+///
+/// sf::SoundStream is a base class that doesn't care about the
+/// stream source, which is left to the derived class. SFML provides
+/// a built-in specialization for big files (see sf::Music).
+/// No network stream source is provided, but you can write your own
+/// by combining this class with the network module.
+///
+/// A derived class has to override two virtual functions:
+/// \li onGetData fills a new chunk of audio data to be played
+/// \li onSeek changes the current playing position in the source
+///
+/// It is important to note that each SoundStream is played in its
+/// own separate thread, so that the streaming loop doesn't block the
+/// rest of the program. In particular, the OnGetData and OnSeek
+/// virtual functions may sometimes be called from this separate thread.
+/// It is important to keep this in mind, because you may have to take
+/// care of synchronization issues if you share data between threads.
+///
+/// Usage example:
+/// \code
+/// class CustomStream : public sf::SoundStream
+/// {
+/// public:
+///
+///     bool open(const std::string& location)
+///     {
+///         // Open the source and get audio settings
+///         ...
+///         unsigned int channelCount = ...;
+///         unsigned int sampleRate = ...;
+///
+///         // Initialize the stream -- important!
+///         initialize(channelCount, sampleRate);
+///     }
+///
+/// private:
+///
+///     virtual bool onGetData(Chunk& data)
+///     {
+///         // Fill the chunk with audio data from the stream source
+///         // (note: must not be empty if you want to continue playing)
+///         data.samples = ...;
+///         data.sampleCount = ...;
+///
+///         // Return true to continue playing
+///         return true;
+///     }
+///
+///     virtual void onSeek(Uint32 timeOffset)
+///     {
+///         // Change the current position in the stream source
+///         ...
+///     }
+/// }
+///
+/// // Usage
+/// CustomStream stream;
+/// stream.open("path/to/stream");
+/// stream.play();
+/// \endcode
+///
+/// \see sf::Music
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Config.hpp
+++ b/libs/include/SFML/Config.hpp
@@ -1,0 +1,236 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CONFIG_HPP
+#define SFML_CONFIG_HPP
+
+
+////////////////////////////////////////////////////////////
+// Define the SFML version
+////////////////////////////////////////////////////////////
+#define SFML_VERSION_MAJOR 2
+#define SFML_VERSION_MINOR 5
+#define SFML_VERSION_PATCH 1
+
+
+////////////////////////////////////////////////////////////
+// Identify the operating system
+// see http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system
+////////////////////////////////////////////////////////////
+#if defined(_WIN32)
+
+    // Windows
+    #define SFML_SYSTEM_WINDOWS
+    #ifndef NOMINMAX
+        #define NOMINMAX
+    #endif
+
+#elif defined(__APPLE__) && defined(__MACH__)
+
+    // Apple platform, see which one it is
+    #include "TargetConditionals.h"
+
+    #if TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR
+
+        // iOS
+        #define SFML_SYSTEM_IOS
+
+    #elif TARGET_OS_MAC
+
+        // MacOS
+        #define SFML_SYSTEM_MACOS
+
+    #else
+
+        // Unsupported Apple system
+        #error This Apple operating system is not supported by SFML library
+
+    #endif
+
+#elif defined(__unix__)
+
+    // UNIX system, see which one it is
+    #if defined(__ANDROID__)
+
+        // Android
+        #define SFML_SYSTEM_ANDROID
+
+    #elif defined(__linux__)
+
+         // Linux
+        #define SFML_SYSTEM_LINUX
+
+    #elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+
+        // FreeBSD
+        #define SFML_SYSTEM_FREEBSD
+
+    #elif defined(__OpenBSD__)
+
+        // OpenBSD
+        #define SFML_SYSTEM_OPENBSD
+
+    #else
+
+        // Unsupported UNIX system
+        #error This UNIX operating system is not supported by SFML library
+
+    #endif
+
+#else
+
+    // Unsupported system
+    #error This operating system is not supported by SFML library
+
+#endif
+
+
+////////////////////////////////////////////////////////////
+// Define a portable debug macro
+////////////////////////////////////////////////////////////
+#if !defined(NDEBUG)
+
+    #define SFML_DEBUG
+
+#endif
+
+
+////////////////////////////////////////////////////////////
+// Define helpers to create portable import / export macros for each module
+////////////////////////////////////////////////////////////
+#if !defined(SFML_STATIC)
+
+    #if defined(SFML_SYSTEM_WINDOWS)
+
+        // Windows compilers need specific (and different) keywords for export and import
+        #define SFML_API_EXPORT __declspec(dllexport)
+        #define SFML_API_IMPORT __declspec(dllimport)
+
+        // For Visual C++ compilers, we also need to turn off this annoying C4251 warning
+        #ifdef _MSC_VER
+
+            #pragma warning(disable: 4251)
+
+        #endif
+
+    #else // Linux, FreeBSD, Mac OS X
+
+        #if __GNUC__ >= 4
+
+            // GCC 4 has special keywords for showing/hidding symbols,
+            // the same keyword is used for both importing and exporting
+            #define SFML_API_EXPORT __attribute__ ((__visibility__ ("default")))
+            #define SFML_API_IMPORT __attribute__ ((__visibility__ ("default")))
+
+        #else
+
+            // GCC < 4 has no mechanism to explicitely hide symbols, everything's exported
+            #define SFML_API_EXPORT
+            #define SFML_API_IMPORT
+
+        #endif
+
+    #endif
+
+#else
+
+    // Static build doesn't need import/export macros
+    #define SFML_API_EXPORT
+    #define SFML_API_IMPORT
+
+#endif
+
+
+////////////////////////////////////////////////////////////
+// Cross-platform warning for deprecated functions and classes
+//
+// Usage:
+// class SFML_DEPRECATED MyClass
+// {
+//     SFML_DEPRECATED void memberFunc();
+// };
+//
+// SFML_DEPRECATED void globalFunc();
+////////////////////////////////////////////////////////////
+#if defined(SFML_NO_DEPRECATED_WARNINGS)
+
+    // User explicitly requests to disable deprecation warnings
+    #define SFML_DEPRECATED
+
+#elif defined(_MSC_VER)
+
+    // Microsoft C++ compiler
+    // Note: On newer MSVC versions, using deprecated functions causes a compiler error. In order to
+    // trigger a warning instead of an error, the compiler flag /sdl- (instead of /sdl) must be specified.
+    #define SFML_DEPRECATED __declspec(deprecated)
+
+#elif defined(__GNUC__)
+
+    // g++ and Clang
+    #define SFML_DEPRECATED __attribute__ ((deprecated))
+
+#else
+
+    // Other compilers are not supported, leave class or function as-is.
+    // With a bit of luck, the #pragma directive works, otherwise users get a warning (no error!) for unrecognized #pragma.
+    #pragma message("SFML_DEPRECATED is not supported for your compiler, please contact the SFML team")
+    #define SFML_DEPRECATED
+
+#endif
+
+
+////////////////////////////////////////////////////////////
+// Define portable fixed-size types
+////////////////////////////////////////////////////////////
+namespace sf
+{
+    // All "common" platforms use the same size for char, short and int
+    // (basically there are 3 types for 3 sizes, so no other match is possible),
+    // we can use them without doing any kind of check
+
+    // 8 bits integer types
+    typedef signed   char Int8;
+    typedef unsigned char Uint8;
+
+    // 16 bits integer types
+    typedef signed   short Int16;
+    typedef unsigned short Uint16;
+
+    // 32 bits integer types
+    typedef signed   int Int32;
+    typedef unsigned int Uint32;
+
+    // 64 bits integer types
+    #if defined(_MSC_VER)
+        typedef signed   __int64 Int64;
+        typedef unsigned __int64 Uint64;
+    #else
+        typedef signed   long long Int64;
+        typedef unsigned long long Uint64;
+    #endif
+
+} // namespace sf
+
+
+#endif // SFML_CONFIG_HPP

--- a/libs/include/SFML/GpuPreference.hpp
+++ b/libs/include/SFML/GpuPreference.hpp
@@ -1,0 +1,74 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_GPUPREFERENCE_HPP
+#define SFML_GPUPREFERENCE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+////////////////////////////////////////////////////////////
+/// \file
+///
+/// \brief File containing SFML_DEFINE_DISCRETE_GPU_PREFERENCE
+///
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+/// \def SFML_DEFINE_DISCRETE_GPU_PREFERENCE
+///
+/// \brief A macro to encourage usage of the discrete GPU
+///
+/// In order to inform the Nvidia/AMD driver that an SFML
+/// application could benefit from using the more powerful
+/// discrete GPU, special symbols have to be publicly
+/// exported from the final executable.
+///
+/// SFML defines a helper macro to easily do this.
+///
+/// Place SFML_DEFINE_DISCRETE_GPU_PREFERENCE in the
+/// global scope of a source file that will be linked into
+/// the final executable. Typically it is best to place it
+/// where the main function is also defined.
+///
+////////////////////////////////////////////////////////////
+#if defined(SFML_SYSTEM_WINDOWS)
+
+    #define SFML_DEFINE_DISCRETE_GPU_PREFERENCE \
+                extern "C" __declspec(dllexport) unsigned long NvOptimusEnablement = 1; \
+                extern "C" __declspec(dllexport) unsigned long AmdPowerXpressRequestHighPerformance = 1;
+
+#else
+
+    #define SFML_DEFINE_DISCRETE_GPU_PREFERENCE
+
+#endif
+
+
+#endif // SFML_GPUPREFERENCE_HPP

--- a/libs/include/SFML/Graphics.hpp
+++ b/libs/include/SFML/Graphics.hpp
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_GRAPHICS_HPP
+#define SFML_GRAPHICS_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
+#include <SFML/Window.hpp>
+#include <SFML/Graphics/BlendMode.hpp>
+#include <SFML/Graphics/CircleShape.hpp>
+#include <SFML/Graphics/Color.hpp>
+#include <SFML/Graphics/ConvexShape.hpp>
+#include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/Font.hpp>
+#include <SFML/Graphics/Glyph.hpp>
+#include <SFML/Graphics/Image.hpp>
+#include <SFML/Graphics/PrimitiveType.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/Graphics/RectangleShape.hpp>
+#include <SFML/Graphics/RenderStates.hpp>
+#include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Graphics/RenderTexture.hpp>
+#include <SFML/Graphics/RenderWindow.hpp>
+#include <SFML/Graphics/Shader.hpp>
+#include <SFML/Graphics/Shape.hpp>
+#include <SFML/Graphics/Sprite.hpp>
+#include <SFML/Graphics/Text.hpp>
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/Transform.hpp>
+#include <SFML/Graphics/Transformable.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+#include <SFML/Graphics/VertexArray.hpp>
+#include <SFML/Graphics/VertexBuffer.hpp>
+#include <SFML/Graphics/View.hpp>
+
+
+#endif // SFML_GRAPHICS_HPP
+
+////////////////////////////////////////////////////////////
+/// \defgroup graphics Graphics module
+///
+/// 2D graphics module: sprites, text, shapes, ...
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/BlendMode.hpp
+++ b/libs/include/SFML/Graphics/BlendMode.hpp
@@ -1,0 +1,215 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_BLENDMODE_HPP
+#define SFML_BLENDMODE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+
+
+namespace sf
+{
+
+////////////////////////////////////////////////////////////
+/// \brief Blending modes for drawing
+///
+////////////////////////////////////////////////////////////
+struct SFML_GRAPHICS_API BlendMode
+{
+    ////////////////////////////////////////////////////////
+    /// \brief Enumeration of the blending factors
+    ///
+    /// The factors are mapped directly to their OpenGL equivalents,
+    /// specified by glBlendFunc() or glBlendFuncSeparate().
+    ////////////////////////////////////////////////////////
+    enum Factor
+    {
+        Zero,             ///< (0, 0, 0, 0)
+        One,              ///< (1, 1, 1, 1)
+        SrcColor,         ///< (src.r, src.g, src.b, src.a)
+        OneMinusSrcColor, ///< (1, 1, 1, 1) - (src.r, src.g, src.b, src.a)
+        DstColor,         ///< (dst.r, dst.g, dst.b, dst.a)
+        OneMinusDstColor, ///< (1, 1, 1, 1) - (dst.r, dst.g, dst.b, dst.a)
+        SrcAlpha,         ///< (src.a, src.a, src.a, src.a)
+        OneMinusSrcAlpha, ///< (1, 1, 1, 1) - (src.a, src.a, src.a, src.a)
+        DstAlpha,         ///< (dst.a, dst.a, dst.a, dst.a)
+        OneMinusDstAlpha  ///< (1, 1, 1, 1) - (dst.a, dst.a, dst.a, dst.a)
+    };
+
+    ////////////////////////////////////////////////////////
+    /// \brief Enumeration of the blending equations
+    ///
+    /// The equations are mapped directly to their OpenGL equivalents,
+    /// specified by glBlendEquation() or glBlendEquationSeparate().
+    ////////////////////////////////////////////////////////
+    enum Equation
+    {
+        Add,            ///< Pixel = Src * SrcFactor + Dst * DstFactor
+        Subtract,       ///< Pixel = Src * SrcFactor - Dst * DstFactor
+        ReverseSubtract ///< Pixel = Dst * DstFactor - Src * SrcFactor
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Constructs a blending mode that does alpha blending.
+    ///
+    ////////////////////////////////////////////////////////////
+    BlendMode();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the blend mode given the factors and equation.
+    ///
+    /// This constructor uses the same factors and equation for both
+    /// color and alpha components. It also defaults to the Add equation.
+    ///
+    /// \param sourceFactor      Specifies how to compute the source factor for the color and alpha channels.
+    /// \param destinationFactor Specifies how to compute the destination factor for the color and alpha channels.
+    /// \param blendEquation     Specifies how to combine the source and destination colors and alpha.
+    ///
+    ////////////////////////////////////////////////////////////
+    BlendMode(Factor sourceFactor, Factor destinationFactor, Equation blendEquation = Add);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the blend mode given the factors and equation.
+    ///
+    /// \param colorSourceFactor      Specifies how to compute the source factor for the color channels.
+    /// \param colorDestinationFactor Specifies how to compute the destination factor for the color channels.
+    /// \param colorBlendEquation     Specifies how to combine the source and destination colors.
+    /// \param alphaSourceFactor      Specifies how to compute the source factor.
+    /// \param alphaDestinationFactor Specifies how to compute the destination factor.
+    /// \param alphaBlendEquation     Specifies how to combine the source and destination alphas.
+    ///
+    ////////////////////////////////////////////////////////////
+    BlendMode(Factor colorSourceFactor, Factor colorDestinationFactor,
+              Equation colorBlendEquation, Factor alphaSourceFactor,
+              Factor alphaDestinationFactor, Equation alphaBlendEquation);
+
+    ////////////////////////////////////////////////////////////
+    // Member Data
+    ////////////////////////////////////////////////////////////
+    Factor   colorSrcFactor; ///< Source blending factor for the color channels
+    Factor   colorDstFactor; ///< Destination blending factor for the color channels
+    Equation colorEquation;  ///< Blending equation for the color channels
+    Factor   alphaSrcFactor; ///< Source blending factor for the alpha channel
+    Factor   alphaDstFactor; ///< Destination blending factor for the alpha channel
+    Equation alphaEquation;  ///< Blending equation for the alpha channel
+};
+
+////////////////////////////////////////////////////////////
+/// \relates BlendMode
+/// \brief Overload of the == operator
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return True if blending modes are equal, false if they are different
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API bool operator ==(const BlendMode& left, const BlendMode& right);
+
+////////////////////////////////////////////////////////////
+/// \relates BlendMode
+/// \brief Overload of the != operator
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return True if blending modes are different, false if they are equal
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API bool operator !=(const BlendMode& left, const BlendMode& right);
+
+////////////////////////////////////////////////////////////
+// Commonly used blending modes
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API extern const BlendMode BlendAlpha;    ///< Blend source and dest according to dest alpha
+SFML_GRAPHICS_API extern const BlendMode BlendAdd;      ///< Add source to dest
+SFML_GRAPHICS_API extern const BlendMode BlendMultiply; ///< Multiply source and dest
+SFML_GRAPHICS_API extern const BlendMode BlendNone;     ///< Overwrite dest with source
+
+} // namespace sf
+
+
+#endif // SFML_BLENDMODE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::BlendMode
+/// \ingroup graphics
+///
+/// sf::BlendMode is a class that represents a blend mode. A blend
+/// mode determines how the colors of an object you draw are
+/// mixed with the colors that are already in the buffer.
+///
+/// The class is composed of 6 components, each of which has its
+/// own public member variable:
+/// \li %Color Source Factor (@ref colorSrcFactor)
+/// \li %Color Destination Factor (@ref colorDstFactor)
+/// \li %Color Blend Equation (@ref colorEquation)
+/// \li Alpha Source Factor (@ref alphaSrcFactor)
+/// \li Alpha Destination Factor (@ref alphaDstFactor)
+/// \li Alpha Blend Equation (@ref alphaEquation)
+///
+/// The source factor specifies how the pixel you are drawing contributes
+/// to the final color. The destination factor specifies how the pixel
+/// already drawn in the buffer contributes to the final color.
+///
+/// The color channels RGB (red, green, blue; simply referred to as
+/// color) and A (alpha; the transparency) can be treated separately. This
+/// separation can be useful for specific blend modes, but most often you
+/// won't need it and will simply treat the color as a single unit.
+///
+/// The blend factors and equations correspond to their OpenGL equivalents.
+/// In general, the color of the resulting pixel is calculated according
+/// to the following formula (\a src is the color of the source pixel, \a dst
+/// the color of the destination pixel, the other variables correspond to the
+/// public members, with the equations being + or - operators):
+/// \code
+/// dst.rgb = colorSrcFactor * src.rgb (colorEquation) colorDstFactor * dst.rgb
+/// dst.a   = alphaSrcFactor * src.a   (alphaEquation) alphaDstFactor * dst.a
+/// \endcode
+/// All factors and colors are represented as floating point numbers between
+/// 0 and 1. Where necessary, the result is clamped to fit in that range.
+///
+/// The most common blending modes are defined as constants
+/// in the sf namespace:
+///
+/// \code
+/// sf::BlendMode alphaBlending          = sf::BlendAlpha;
+/// sf::BlendMode additiveBlending       = sf::BlendAdd;
+/// sf::BlendMode multiplicativeBlending = sf::BlendMultiply;
+/// sf::BlendMode noBlending             = sf::BlendNone;
+/// \endcode
+///
+/// In SFML, a blend mode can be specified every time you draw a sf::Drawable
+/// object to a render target. It is part of the sf::RenderStates compound
+/// that is passed to the member function sf::RenderTarget::draw().
+///
+/// \see sf::RenderStates, sf::RenderTarget
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/CircleShape.hpp
+++ b/libs/include/SFML/Graphics/CircleShape.hpp
@@ -1,0 +1,154 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CIRCLESHAPE_HPP
+#define SFML_CIRCLESHAPE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Shape.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Specialized shape representing a circle
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API CircleShape : public Shape
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// \param radius     Radius of the circle
+    /// \param pointCount Number of points composing the circle
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit CircleShape(float radius = 0, std::size_t pointCount = 30);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the radius of the circle
+    ///
+    /// \param radius New radius of the circle
+    ///
+    /// \see getRadius
+    ///
+    ////////////////////////////////////////////////////////////
+    void setRadius(float radius);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the radius of the circle
+    ///
+    /// \return Radius of the circle
+    ///
+    /// \see setRadius
+    ///
+    ////////////////////////////////////////////////////////////
+    float getRadius() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the number of points of the circle
+    ///
+    /// \param count New number of points of the circle
+    ///
+    /// \see getPointCount
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPointCount(std::size_t count);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the number of points of the circle
+    ///
+    /// \return Number of points of the circle
+    ///
+    /// \see setPointCount
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual std::size_t getPointCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a point of the circle
+    ///
+    /// The returned point is in local coordinates, that is,
+    /// the shape's transforms (position, rotation, scale) are
+    /// not taken into account.
+    /// The result is undefined if \a index is out of the valid range.
+    ///
+    /// \param index Index of the point to get, in range [0 .. getPointCount() - 1]
+    ///
+    /// \return index-th point of the shape
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Vector2f getPoint(std::size_t index) const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    float       m_radius;     ///< Radius of the circle
+    std::size_t m_pointCount; ///< Number of points composing the circle
+};
+
+} // namespace sf
+
+
+#endif // SFML_CIRCLESHAPE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::CircleShape
+/// \ingroup graphics
+///
+/// This class inherits all the functions of sf::Transformable
+/// (position, rotation, scale, bounds, ...) as well as the
+/// functions of sf::Shape (outline, color, texture, ...).
+///
+/// Usage example:
+/// \code
+/// sf::CircleShape circle;
+/// circle.setRadius(150);
+/// circle.setOutlineColor(sf::Color::Red);
+/// circle.setOutlineThickness(5);
+/// circle.setPosition(10, 20);
+/// ...
+/// window.draw(circle);
+/// \endcode
+///
+/// Since the graphics card can't draw perfect circles, we have to
+/// fake them with multiple triangles connected to each other. The
+/// "points count" property of sf::CircleShape defines how many of these
+/// triangles to use, and therefore defines the quality of the circle.
+///
+/// The number of points can also be used for another purpose; with
+/// small numbers you can create any regular polygon shape:
+/// equilateral triangle, square, pentagon, hexagon, ...
+///
+/// \see sf::Shape, sf::RectangleShape, sf::ConvexShape
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Color.hpp
+++ b/libs/include/SFML/Graphics/Color.hpp
@@ -1,0 +1,275 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_COLOR_HPP
+#define SFML_COLOR_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Utility class for manipulating RGBA colors
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Color
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Constructs an opaque black color. It is equivalent to
+    /// sf::Color(0, 0, 0, 255).
+    ///
+    ////////////////////////////////////////////////////////////
+    Color();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the color from its 4 RGBA components
+    ///
+    /// \param red   Red component (in the range [0, 255])
+    /// \param green Green component (in the range [0, 255])
+    /// \param blue  Blue component (in the range [0, 255])
+    /// \param alpha Alpha (opacity) component (in the range [0, 255])
+    ///
+    ////////////////////////////////////////////////////////////
+    Color(Uint8 red, Uint8 green, Uint8 blue, Uint8 alpha = 255);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the color from 32-bit unsigned integer
+    ///
+    /// \param color Number containing the RGBA components (in that order)
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Color(Uint32 color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Retrieve the color as a 32-bit unsigned integer
+    ///
+    /// \return Color represented as a 32-bit unsigned integer
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint32 toInteger() const;
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static const Color Black;       ///< Black predefined color
+    static const Color White;       ///< White predefined color
+    static const Color Red;         ///< Red predefined color
+    static const Color Green;       ///< Green predefined color
+    static const Color Blue;        ///< Blue predefined color
+    static const Color Yellow;      ///< Yellow predefined color
+    static const Color Magenta;     ///< Magenta predefined color
+    static const Color Cyan;        ///< Cyan predefined color
+    static const Color Transparent; ///< Transparent (black) predefined color
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Uint8 r; ///< Red component
+    Uint8 g; ///< Green component
+    Uint8 b; ///< Blue component
+    Uint8 a; ///< Alpha (opacity) component
+};
+
+////////////////////////////////////////////////////////////
+/// \relates Color
+/// \brief Overload of the == operator
+///
+/// This operator compares two colors and check if they are equal.
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return True if colors are equal, false if they are different
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API bool operator ==(const Color& left, const Color& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Color
+/// \brief Overload of the != operator
+///
+/// This operator compares two colors and check if they are different.
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return True if colors are different, false if they are equal
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API bool operator !=(const Color& left, const Color& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Color
+/// \brief Overload of the binary + operator
+///
+/// This operator returns the component-wise sum of two colors.
+/// Components that exceed 255 are clamped to 255.
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return Result of \a left + \a right
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Color operator +(const Color& left, const Color& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Color
+/// \brief Overload of the binary - operator
+///
+/// This operator returns the component-wise subtraction of two colors.
+/// Components below 0 are clamped to 0.
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return Result of \a left - \a right
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Color operator -(const Color& left, const Color& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Color
+/// \brief Overload of the binary * operator
+///
+/// This operator returns the component-wise multiplication
+/// (also called "modulation") of two colors.
+/// Components are then divided by 255 so that the result is
+/// still in the range [0, 255].
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return Result of \a left * \a right
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Color operator *(const Color& left, const Color& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Color
+/// \brief Overload of the binary += operator
+///
+/// This operator computes the component-wise sum of two colors,
+/// and assigns the result to the left operand.
+/// Components that exceed 255 are clamped to 255.
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Color& operator +=(Color& left, const Color& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Color
+/// \brief Overload of the binary -= operator
+///
+/// This operator computes the component-wise subtraction of two colors,
+/// and assigns the result to the left operand.
+/// Components below 0 are clamped to 0.
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Color& operator -=(Color& left, const Color& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Color
+/// \brief Overload of the binary *= operator
+///
+/// This operator returns the component-wise multiplication
+/// (also called "modulation") of two colors, and assigns
+/// the result to the left operand.
+/// Components are then divided by 255 so that the result is
+/// still in the range [0, 255].
+///
+/// \param left  Left operand
+/// \param right Right operand
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Color& operator *=(Color& left, const Color& right);
+
+} // namespace sf
+
+
+#endif // SFML_COLOR_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Color
+/// \ingroup graphics
+///
+/// sf::Color is a simple color class composed of 4 components:
+/// \li Red
+/// \li Green
+/// \li Blue
+/// \li Alpha (opacity)
+///
+/// Each component is a public member, an unsigned integer in
+/// the range [0, 255]. Thus, colors can be constructed and
+/// manipulated very easily:
+///
+/// \code
+/// sf::Color color(255, 0, 0); // red
+/// color.r = 0;                // make it black
+/// color.b = 128;              // make it dark blue
+/// \endcode
+///
+/// The fourth component of colors, named "alpha", represents
+/// the opacity of the color. A color with an alpha value of
+/// 255 will be fully opaque, while an alpha value of 0 will
+/// make a color fully transparent, whatever the value of the
+/// other components is.
+///
+/// The most common colors are already defined as static variables:
+/// \code
+/// sf::Color black       = sf::Color::Black;
+/// sf::Color white       = sf::Color::White;
+/// sf::Color red         = sf::Color::Red;
+/// sf::Color green       = sf::Color::Green;
+/// sf::Color blue        = sf::Color::Blue;
+/// sf::Color yellow      = sf::Color::Yellow;
+/// sf::Color magenta     = sf::Color::Magenta;
+/// sf::Color cyan        = sf::Color::Cyan;
+/// sf::Color transparent = sf::Color::Transparent;
+/// \endcode
+///
+/// Colors can also be added and modulated (multiplied) using the
+/// overloaded operators + and *.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/ConvexShape.hpp
+++ b/libs/include/SFML/Graphics/ConvexShape.hpp
@@ -1,0 +1,153 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CONVEXSHAPE_HPP
+#define SFML_CONVEXSHAPE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Shape.hpp>
+#include <vector>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Specialized shape representing a convex polygon
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API ConvexShape : public Shape
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// \param pointCount Number of points of the polygon
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit ConvexShape(std::size_t pointCount = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the number of points of the polygon
+    ///
+    /// \a count must be greater than 2 to define a valid shape.
+    ///
+    /// \param count New number of points of the polygon
+    ///
+    /// \see getPointCount
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPointCount(std::size_t count);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the number of points of the polygon
+    ///
+    /// \return Number of points of the polygon
+    ///
+    /// \see setPointCount
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual std::size_t getPointCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the position of a point
+    ///
+    /// Don't forget that the polygon must remain convex, and
+    /// the points need to stay ordered!
+    /// setPointCount must be called first in order to set the total
+    /// number of points. The result is undefined if \a index is out
+    /// of the valid range.
+    ///
+    /// \param index Index of the point to change, in range [0 .. getPointCount() - 1]
+    /// \param point New position of the point
+    ///
+    /// \see getPoint
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPoint(std::size_t index, const Vector2f& point);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the position of a point
+    ///
+    /// The returned point is in local coordinates, that is,
+    /// the shape's transforms (position, rotation, scale) are
+    /// not taken into account.
+    /// The result is undefined if \a index is out of the valid range.
+    ///
+    /// \param index Index of the point to get, in range [0 .. getPointCount() - 1]
+    ///
+    /// \return Position of the index-th point of the polygon
+    ///
+    /// \see setPoint
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Vector2f getPoint(std::size_t index) const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::vector<Vector2f> m_points; ///< Points composing the convex polygon
+};
+
+} // namespace sf
+
+
+#endif // SFML_CONVEXSHAPE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::ConvexShape
+/// \ingroup graphics
+///
+/// This class inherits all the functions of sf::Transformable
+/// (position, rotation, scale, bounds, ...) as well as the
+/// functions of sf::Shape (outline, color, texture, ...).
+///
+/// It is important to keep in mind that a convex shape must
+/// always be... convex, otherwise it may not be drawn correctly.
+/// Moreover, the points must be defined in order; using a random
+/// order would result in an incorrect shape.
+///
+/// Usage example:
+/// \code
+/// sf::ConvexShape polygon;
+/// polygon.setPointCount(3);
+/// polygon.setPoint(0, sf::Vector2f(0, 0));
+/// polygon.setPoint(1, sf::Vector2f(0, 10));
+/// polygon.setPoint(2, sf::Vector2f(25, 5));
+/// polygon.setOutlineColor(sf::Color::Red);
+/// polygon.setOutlineThickness(5);
+/// polygon.setPosition(10, 20);
+/// ...
+/// window.draw(polygon);
+/// \endcode
+///
+/// \see sf::Shape, sf::RectangleShape, sf::CircleShape
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Drawable.hpp
+++ b/libs/include/SFML/Graphics/Drawable.hpp
@@ -1,0 +1,126 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_DRAWABLE_HPP
+#define SFML_DRAWABLE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/RenderStates.hpp>
+
+
+namespace sf
+{
+class RenderTarget;
+
+////////////////////////////////////////////////////////////
+/// \brief Abstract base class for objects that can be drawn
+///        to a render target
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Drawable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Virtual destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~Drawable() {}
+
+protected:
+
+    friend class RenderTarget;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw the object to a render target
+    ///
+    /// This is a pure virtual function that has to be implemented
+    /// by the derived class to define how the drawable should be
+    /// drawn.
+    ///
+    /// \param target Render target to draw to
+    /// \param states Current render states
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void draw(RenderTarget& target, RenderStates states) const = 0;
+};
+
+} // namespace sf
+
+
+#endif // SFML_DRAWABLE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Drawable
+/// \ingroup graphics
+///
+/// sf::Drawable is a very simple base class that allows objects
+/// of derived classes to be drawn to a sf::RenderTarget.
+///
+/// All you have to do in your derived class is to override the
+/// draw virtual function.
+///
+/// Note that inheriting from sf::Drawable is not mandatory,
+/// but it allows this nice syntax "window.draw(object)" rather
+/// than "object.draw(window)", which is more consistent with other
+/// SFML classes.
+///
+/// Example:
+/// \code
+/// class MyDrawable : public sf::Drawable
+/// {
+/// public:
+///
+///    ...
+///
+/// private:
+///
+///     virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const
+///     {
+///         // You can draw other high-level objects
+///         target.draw(m_sprite, states);
+///
+///         // ... or use the low-level API
+///         states.texture = &m_texture;
+///         target.draw(m_vertices, states);
+///
+///         // ... or draw with OpenGL directly
+///         glBegin(GL_QUADS);
+///         ...
+///         glEnd();
+///     }
+///
+///     sf::Sprite m_sprite;
+///     sf::Texture m_texture;
+///     sf::VertexArray m_vertices;
+/// };
+/// \endcode
+///
+/// \see sf::RenderTarget
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Export.hpp
+++ b/libs/include/SFML/Graphics/Export.hpp
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_GRAPHICS_EXPORT_HPP
+#define SFML_GRAPHICS_EXPORT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+////////////////////////////////////////////////////////////
+// Define portable import / export macros
+////////////////////////////////////////////////////////////
+#if defined(SFML_GRAPHICS_EXPORTS)
+
+    #define SFML_GRAPHICS_API SFML_API_EXPORT
+
+#else
+
+    #define SFML_GRAPHICS_API SFML_API_IMPORT
+
+#endif
+
+
+#endif // SFML_GRAPHICS_EXPORT_HPP

--- a/libs/include/SFML/Graphics/Font.hpp
+++ b/libs/include/SFML/Graphics/Font.hpp
@@ -1,0 +1,439 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_FONT_HPP
+#define SFML_FONT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Glyph.hpp>
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/System/String.hpp>
+#include <map>
+#include <string>
+#include <vector>
+
+
+namespace sf
+{
+class InputStream;
+
+////////////////////////////////////////////////////////////
+/// \brief Class for loading and manipulating character fonts
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Font
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Holds various information about a font
+    ///
+    ////////////////////////////////////////////////////////////
+    struct Info
+    {
+        std::string family; ///< The font family
+    };
+
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor defines an empty font
+    ///
+    ////////////////////////////////////////////////////////////
+    Font();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    Font(const Font& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// Cleans up all the internal resources used by the font
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Font();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the font from a file
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    /// Note that this function knows nothing about the standard
+    /// fonts installed on the user's system, thus you can't
+    /// load them directly.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the file has to remain accessible until
+    /// the sf::Font object loads a new font or is destroyed.
+    ///
+    /// \param filename Path of the font file to load
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromFile(const std::string& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the font from a file in memory
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the buffer pointed by \a data has to remain
+    /// valid until the sf::Font object loads a new font or
+    /// is destroyed.
+    ///
+    /// \param data        Pointer to the file data in memory
+    /// \param sizeInBytes Size of the data to load, in bytes
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromMemory(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the font from a custom stream
+    ///
+    /// The supported font formats are: TrueType, Type 1, CFF,
+    /// OpenType, SFNT, X11 PCF, Windows FNT, BDF, PFR and Type 42.
+    /// Warning: SFML cannot preload all the font data in this
+    /// function, so the contents of \a stream have to remain
+    /// valid as long as the font is used.
+    ///
+    /// \warning SFML cannot preload all the font data in this
+    /// function, so the stream has to remain accessible until
+    /// the sf::Font object loads a new font or is destroyed.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the font information
+    ///
+    /// \return A structure that holds the font information
+    ///
+    ////////////////////////////////////////////////////////////
+    const Info& getInfo() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Retrieve a glyph of the font
+    ///
+    /// If the font is a bitmap font, not all character sizes
+    /// might be available. If the glyph is not available at the
+    /// requested size, an empty glyph is returned.
+    ///
+    /// Be aware that using a negative value for the outline
+    /// thickness will cause distorted rendering.
+    ///
+    /// \param codePoint        Unicode code point of the character to get
+    /// \param characterSize    Reference character size
+    /// \param bold             Retrieve the bold version or the regular one?
+    /// \param outlineThickness Thickness of outline (when != 0 the glyph will not be filled)
+    ///
+    /// \return The glyph corresponding to \a codePoint and \a characterSize
+    ///
+    ////////////////////////////////////////////////////////////
+    const Glyph& getGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, float outlineThickness = 0) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the kerning offset of two glyphs
+    ///
+    /// The kerning is an extra offset (negative) to apply between two
+    /// glyphs when rendering them, to make the pair look more "natural".
+    /// For example, the pair "AV" have a special kerning to make them
+    /// closer than other characters. Most of the glyphs pairs have a
+    /// kerning offset of zero, though.
+    ///
+    /// \param first         Unicode code point of the first character
+    /// \param second        Unicode code point of the second character
+    /// \param characterSize Reference character size
+    ///
+    /// \return Kerning value for \a first and \a second, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    float getKerning(Uint32 first, Uint32 second, unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the line spacing
+    ///
+    /// Line spacing is the vertical offset to apply between two
+    /// consecutive lines of text.
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return Line spacing, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    float getLineSpacing(unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the position of the underline
+    ///
+    /// Underline position is the vertical offset to apply between the
+    /// baseline and the underline.
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return Underline position, in pixels
+    ///
+    /// \see getUnderlineThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    float getUnderlinePosition(unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the thickness of the underline
+    ///
+    /// Underline thickness is the vertical size of the underline.
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return Underline thickness, in pixels
+    ///
+    /// \see getUnderlinePosition
+    ///
+    ////////////////////////////////////////////////////////////
+    float getUnderlineThickness(unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Retrieve the texture containing the loaded glyphs of a certain size
+    ///
+    /// The contents of the returned texture changes as more glyphs
+    /// are requested, thus it is not very relevant. It is mainly
+    /// used internally by sf::Text.
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return Texture containing the glyphs of the requested size
+    ///
+    ////////////////////////////////////////////////////////////
+    const Texture& getTexture(unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    Font& operator =(const Font& right);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Structure defining a row of glyphs
+    ///
+    ////////////////////////////////////////////////////////////
+    struct Row
+    {
+        Row(unsigned int rowTop, unsigned int rowHeight) : width(0), top(rowTop), height(rowHeight) {}
+
+        unsigned int width;  ///< Current width of the row
+        unsigned int top;    ///< Y position of the row into the texture
+        unsigned int height; ///< Height of the row
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::map<Uint64, Glyph> GlyphTable; ///< Table mapping a codepoint to its glyph
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Structure defining a page of glyphs
+    ///
+    ////////////////////////////////////////////////////////////
+    struct Page
+    {
+        Page();
+
+        GlyphTable       glyphs;  ///< Table mapping code points to their corresponding glyph
+        Texture          texture; ///< Texture containing the pixels of the glyphs
+        unsigned int     nextRow; ///< Y position of the next new row in the texture
+        std::vector<Row> rows;    ///< List containing the position of all the existing rows
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Free all the internal resources
+    ///
+    ////////////////////////////////////////////////////////////
+    void cleanup();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load a new glyph and store it in the cache
+    ///
+    /// \param codePoint        Unicode code point of the character to load
+    /// \param characterSize    Reference character size
+    /// \param bold             Retrieve the bold version or the regular one?
+    /// \param outlineThickness Thickness of outline (when != 0 the glyph will not be filled)
+    ///
+    /// \return The glyph corresponding to \a codePoint and \a characterSize
+    ///
+    ////////////////////////////////////////////////////////////
+    Glyph loadGlyph(Uint32 codePoint, unsigned int characterSize, bool bold, float outlineThickness) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Find a suitable rectangle within the texture for a glyph
+    ///
+    /// \param page   Page of glyphs to search in
+    /// \param width  Width of the rectangle
+    /// \param height Height of the rectangle
+    ///
+    /// \return Found rectangle within the texture
+    ///
+    ////////////////////////////////////////////////////////////
+    IntRect findGlyphRect(Page& page, unsigned int width, unsigned int height) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Make sure that the given size is the current one
+    ///
+    /// \param characterSize Reference character size
+    ///
+    /// \return True on success, false if any error happened
+    ///
+    ////////////////////////////////////////////////////////////
+    bool setCurrentSize(unsigned int characterSize) const;
+
+    ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::map<unsigned int, Page> PageTable; ///< Table mapping a character size to its page (texture)
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    void*                      m_library;     ///< Pointer to the internal library interface (it is typeless to avoid exposing implementation details)
+    void*                      m_face;        ///< Pointer to the internal font face (it is typeless to avoid exposing implementation details)
+    void*                      m_streamRec;   ///< Pointer to the stream rec instance (it is typeless to avoid exposing implementation details)
+    void*                      m_stroker;     ///< Pointer to the stroker (it is typeless to avoid exposing implementation details)
+    int*                       m_refCount;    ///< Reference counter used by implicit sharing
+    Info                       m_info;        ///< Information about the font
+    mutable PageTable          m_pages;       ///< Table containing the glyphs pages by character size
+    mutable std::vector<Uint8> m_pixelBuffer; ///< Pixel buffer holding a glyph's pixels before being written to the texture
+    #ifdef SFML_SYSTEM_ANDROID
+    void*                      m_stream; ///< Asset file streamer (if loaded from file)
+    #endif
+};
+
+} // namespace sf
+
+
+#endif // SFML_FONT_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Font
+/// \ingroup graphics
+///
+/// Fonts can be loaded from a file, from memory or from a custom
+/// stream, and supports the most common types of fonts. See
+/// the loadFromFile function for the complete list of supported formats.
+///
+/// Once it is loaded, a sf::Font instance provides three
+/// types of information about the font:
+/// \li Global metrics, such as the line spacing
+/// \li Per-glyph metrics, such as bounding box or kerning
+/// \li Pixel representation of glyphs
+///
+/// Fonts alone are not very useful: they hold the font data
+/// but cannot make anything useful of it. To do so you need to
+/// use the sf::Text class, which is able to properly output text
+/// with several options such as character size, style, color,
+/// position, rotation, etc.
+/// This separation allows more flexibility and better performances:
+/// indeed a sf::Font is a heavy resource, and any operation on it
+/// is slow (often too slow for real-time applications). On the other
+/// side, a sf::Text is a lightweight object which can combine the
+/// glyphs data and metrics of a sf::Font to display any text on a
+/// render target.
+/// Note that it is also possible to bind several sf::Text instances
+/// to the same sf::Font.
+///
+/// It is important to note that the sf::Text instance doesn't
+/// copy the font that it uses, it only keeps a reference to it.
+/// Thus, a sf::Font must not be destructed while it is
+/// used by a sf::Text (i.e. never write a function that
+/// uses a local sf::Font instance for creating a text).
+///
+/// Usage example:
+/// \code
+/// // Declare a new font
+/// sf::Font font;
+///
+/// // Load it from a file
+/// if (!font.loadFromFile("arial.ttf"))
+/// {
+///     // error...
+/// }
+///
+/// // Create a text which uses our font
+/// sf::Text text1;
+/// text1.setFont(font);
+/// text1.setCharacterSize(30);
+/// text1.setStyle(sf::Text::Regular);
+///
+/// // Create another text using the same font, but with different parameters
+/// sf::Text text2;
+/// text2.setFont(font);
+/// text2.setCharacterSize(50);
+/// text2.setStyle(sf::Text::Italic);
+/// \endcode
+///
+/// Apart from loading font files, and passing them to instances
+/// of sf::Text, you should normally not have to deal directly
+/// with this class. However, it may be useful to access the
+/// font metrics or rasterized glyphs for advanced usage.
+///
+/// Note that if the font is a bitmap font, it is not scalable,
+/// thus not all requested sizes will be available to use. This
+/// needs to be taken into consideration when using sf::Text.
+/// If you need to display text of a certain size, make sure the
+/// corresponding bitmap font that supports that size is used.
+///
+/// \see sf::Text
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Glsl.hpp
+++ b/libs/include/SFML/Graphics/Glsl.hpp
@@ -1,0 +1,227 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_GLSL_HPP
+#define SFML_GLSL_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Transform.hpp>
+#include <SFML/Graphics/Color.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/System/Vector3.hpp>
+
+
+namespace sf
+{
+namespace priv
+{
+    // Forward declarations
+    template <std::size_t Columns, std::size_t Rows>
+    struct Matrix;
+
+    template <typename T>
+    struct Vector4;
+
+#include <SFML/Graphics/Glsl.inl>
+
+} // namespace priv
+
+
+////////////////////////////////////////////////////////////
+/// \brief Namespace with GLSL types
+///
+////////////////////////////////////////////////////////////
+namespace Glsl
+{
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 2D float vector (\p vec2 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector2<float> Vec2;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 2D int vector (\p ivec2 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector2<int> Ivec2;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 2D bool vector (\p bvec2 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector2<bool> Bvec2;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 3D float vector (\p vec3 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector3<float> Vec3;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 3D int vector (\p ivec3 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector3<int> Ivec3;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 3D bool vector (\p bvec3 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef Vector3<bool> Bvec3;
+
+#ifdef SFML_DOXYGEN
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 4D float vector (\p vec4 in GLSL)
+    ///
+    /// 4D float vectors can be implicitly converted from sf::Color
+    /// instances. Each color channel is normalized from integers
+    /// in [0, 255] to floating point values in [0, 1].
+    /// \code
+    /// sf::Glsl::Vec4 zeroVector;
+    /// sf::Glsl::Vec4 vector(1.f, 2.f, 3.f, 4.f);
+    /// sf::Glsl::Vec4 color = sf::Color::Cyan;
+    /// \endcode
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Vec4;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 4D int vector (\p ivec4 in GLSL)
+    ///
+    /// 4D int vectors can be implicitly converted from sf::Color
+    /// instances. Each color channel remains unchanged inside
+    /// the integer interval [0, 255].
+    /// \code
+    /// sf::Glsl::Ivec4 zeroVector;
+    /// sf::Glsl::Ivec4 vector(1, 2, 3, 4);
+    /// sf::Glsl::Ivec4 color = sf::Color::Cyan;
+    /// \endcode
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Ivec4;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 4D bool vector (\p bvec4 in GLSL)
+    ///
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Bvec4;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 3x3 float matrix (\p mat3 in GLSL)
+    ///
+    /// The matrix can be constructed from an array with 3x3
+    /// elements, aligned in column-major order. For example,
+    /// a translation by (x, y) looks as follows:
+    /// \code
+    /// float array[9] =
+    /// {
+    ///     1, 0, 0,
+    ///     0, 1, 0,
+    ///     x, y, 1
+    /// };
+    ///
+    /// sf::Glsl::Mat3 matrix(array);
+    /// \endcode
+    ///
+    /// Mat3 can also be implicitly converted from sf::Transform:
+    /// \code
+    /// sf::Transform transform;
+    /// sf::Glsl::Mat3 matrix = transform;
+    /// \endcode
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Mat3;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief 4x4 float matrix (\p mat4 in GLSL)
+    ///
+    /// The matrix can be constructed from an array with 4x4
+    /// elements, aligned in column-major order. For example,
+    /// a translation by (x, y, z) looks as follows:
+    /// \code
+    /// float array[16] =
+    /// {
+    ///     1, 0, 0, 0,
+    ///     0, 1, 0, 0,
+    ///     0, 0, 1, 0,
+    ///     x, y, z, 1
+    /// };
+    ///
+    /// sf::Glsl::Mat4 matrix(array);
+    /// \endcode
+    ///
+    /// Mat4 can also be implicitly converted from sf::Transform:
+    /// \code
+    /// sf::Transform transform;
+    /// sf::Glsl::Mat4 matrix = transform;
+    /// \endcode
+    ////////////////////////////////////////////////////////////
+    typedef implementation-defined Mat4;
+
+#else // SFML_DOXYGEN
+
+    typedef priv::Vector4<float> Vec4;
+    typedef priv::Vector4<int> Ivec4;
+    typedef priv::Vector4<bool> Bvec4;
+    typedef priv::Matrix<3, 3> Mat3;
+    typedef priv::Matrix<4, 4> Mat4;
+
+#endif // SFML_DOXYGEN
+
+} // namespace Glsl
+} // namespace sf
+
+#endif // SFML_GLSL_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \namespace sf::Glsl
+/// \ingroup graphics
+///
+/// \details The sf::Glsl namespace contains types that match
+/// their equivalents in GLSL, the OpenGL shading language.
+/// These types are exclusively used by the sf::Shader class.
+///
+/// Types that already exist in SFML, such as \ref sf::Vector2<T>
+/// and \ref sf::Vector3<T>, are reused as typedefs, so you can use
+/// the types in this namespace as well as the original ones.
+/// Others are newly defined, such as Glsl::Vec4 or Glsl::Mat3. Their
+/// actual type is an implementation detail and should not be used.
+///
+/// All vector types support a default constructor that
+/// initializes every component to zero, in addition to a
+/// constructor with one parameter for each component.
+/// The components are stored in member variables called
+/// x, y, z, and w.
+///
+/// All matrix types support a constructor with a float*
+/// parameter that points to a float array of the appropriate
+/// size (that is, 9 in a 3x3 matrix, 16 in a 4x4 matrix).
+/// Furthermore, they can be converted from sf::Transform
+/// objects.
+///
+/// \see sf::Shader
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Glsl.inl
+++ b/libs/include/SFML/Graphics/Glsl.inl
@@ -1,0 +1,155 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+/// \brief Helper functions to copy sf::Transform to sf::Glsl::Mat3/4
+///
+////////////////////////////////////////////////////////////
+void SFML_GRAPHICS_API copyMatrix(const Transform& source, Matrix<3, 3>& dest);
+void SFML_GRAPHICS_API copyMatrix(const Transform& source, Matrix<4, 4>& dest);
+
+////////////////////////////////////////////////////////////
+/// \brief Copy array-based matrix with given number of elements
+///
+/// Indirection to std::copy() to avoid inclusion of
+/// <algorithm> and MSVC's annoying 4996 warning in header
+///
+////////////////////////////////////////////////////////////
+void SFML_GRAPHICS_API copyMatrix(const float* source, std::size_t elements, float* dest);
+
+////////////////////////////////////////////////////////////
+/// \brief Helper functions to copy sf::Color to sf::Glsl::Vec4/Ivec4
+///
+////////////////////////////////////////////////////////////
+void SFML_GRAPHICS_API copyVector(const Color& source, Vector4<float>& dest);
+void SFML_GRAPHICS_API copyVector(const Color& source, Vector4<int>& dest);
+
+
+////////////////////////////////////////////////////////////
+/// \brief Matrix type, used to set uniforms in GLSL
+///
+////////////////////////////////////////////////////////////
+template <std::size_t Columns, std::size_t Rows>
+struct Matrix
+{
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from raw data
+    ///
+    /// \param pointer Points to the beginning of an array that
+    ///                has the size of the matrix. The elements
+    ///                are copied to the instance.
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Matrix(const float* pointer)
+    {
+        copyMatrix(pointer, Columns * Rows, array);
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct implicitly from SFML transform
+    ///
+    /// This constructor is only supported for 3x3 and 4x4
+    /// matrices.
+    ///
+    /// \param transform Object containing a transform.
+    ///
+    ////////////////////////////////////////////////////////////
+    Matrix(const Transform& transform)
+    {
+        copyMatrix(transform, *this);
+    }
+
+    float array[Columns * Rows]; ///< Array holding matrix data
+};
+
+////////////////////////////////////////////////////////////
+/// \brief 4D vector type, used to set uniforms in GLSL
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+struct Vector4
+{
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor, creates a zero vector
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector4() :
+    x(0),
+    y(0),
+    z(0),
+    w(0)
+    {
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from 4 vector components
+    ///
+    /// \param X Component of the 4D vector
+    /// \param Y Component of the 4D vector
+    /// \param Z Component of the 4D vector
+    /// \param W Component of the 4D vector
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector4(T X, T Y, T Z, T W) :
+    x(X),
+    y(Y),
+    z(Z),
+    w(W)
+    {
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Conversion constructor
+    ///
+    /// \param other 4D vector of different type
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename U>
+    explicit Vector4(const Vector4<U>& other) :
+    x(static_cast<T>(other.x)),
+    y(static_cast<T>(other.y)),
+    z(static_cast<T>(other.z)),
+    w(static_cast<T>(other.w))
+    {
+    }
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct float vector implicitly from color
+    ///
+    /// \param color Color instance. Is normalized to [0, 1]
+    ///              for floats, and left as-is for ints.
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector4(const Color& color)
+    // uninitialized
+    {
+        copyVector(color, *this);
+    }
+
+    T x; ///< 1st component (X) of the 4D vector
+    T y; ///< 2nd component (Y) of the 4D vector
+    T z; ///< 3rd component (Z) of the 4D vector
+    T w; ///< 4th component (W) of the 4D vector
+};

--- a/libs/include/SFML/Graphics/Glyph.hpp
+++ b/libs/include/SFML/Graphics/Glyph.hpp
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_GLYPH_HPP
+#define SFML_GLYPH_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Rect.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Structure describing a glyph
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Glyph
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Glyph() : advance(0) {}
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    float     advance;     ///< Offset to move horizontally to the next character
+    FloatRect bounds;      ///< Bounding rectangle of the glyph, in coordinates relative to the baseline
+    IntRect   textureRect; ///< Texture coordinates of the glyph inside the font's texture
+};
+
+} // namespace sf
+
+
+#endif // SFML_GLYPH_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Glyph
+/// \ingroup graphics
+///
+/// A glyph is the visual representation of a character.
+///
+/// The sf::Glyph structure provides the information needed
+/// to handle the glyph:
+/// \li its coordinates in the font's texture
+/// \li its bounding rectangle
+/// \li the offset to apply to get the starting position of the next glyph
+///
+/// \see sf::Font
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Image.hpp
+++ b/libs/include/SFML/Graphics/Image.hpp
@@ -1,0 +1,324 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_IMAGE_HPP
+#define SFML_IMAGE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Color.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <string>
+#include <vector>
+
+
+namespace sf
+{
+class InputStream;
+
+////////////////////////////////////////////////////////////
+/// \brief Class for loading, manipulating and saving images
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Image
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty image.
+    ///
+    ////////////////////////////////////////////////////////////
+    Image();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Image();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the image and fill it with a unique color
+    ///
+    /// \param width  Width of the image
+    /// \param height Height of the image
+    /// \param color  Fill color
+    ///
+    ////////////////////////////////////////////////////////////
+    void create(unsigned int width, unsigned int height, const Color& color = Color(0, 0, 0));
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the image from an array of pixels
+    ///
+    /// The \a pixel array is assumed to contain 32-bits RGBA pixels,
+    /// and have the given \a width and \a height. If not, this is
+    /// an undefined behavior.
+    /// If \a pixels is null, an empty image is created.
+    ///
+    /// \param width  Width of the image
+    /// \param height Height of the image
+    /// \param pixels Array of pixels to copy to the image
+    ///
+    ////////////////////////////////////////////////////////////
+    void create(unsigned int width, unsigned int height, const Uint8* pixels);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the image from a file on disk
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr and pic. Some format options are not supported,
+    /// like progressive jpeg.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param filename Path of the image file to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromMemory, loadFromStream, saveToFile
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromFile(const std::string& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the image from a file in memory
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr and pic. Some format options are not supported,
+    /// like progressive jpeg.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromMemory(const void* data, std::size_t size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the image from a custom stream
+    ///
+    /// The supported image formats are bmp, png, tga, jpg, gif,
+    /// psd, hdr and pic. Some format options are not supported,
+    /// like progressive jpeg.
+    /// If this function fails, the image is left unchanged.
+    ///
+    /// \param stream Source stream to read from
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromStream(InputStream& stream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Save the image to a file on disk
+    ///
+    /// The format of the image is automatically deduced from
+    /// the extension. The supported image formats are bmp, png,
+    /// tga and jpg. The destination file is overwritten
+    /// if it already exists. This function fails if the image is empty.
+    ///
+    /// \param filename Path of the file to save
+    ///
+    /// \return True if saving was successful
+    ///
+    /// \see create, loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    bool saveToFile(const std::string& filename) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the size (width and height) of the image
+    ///
+    /// \return Size of the image, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2u getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a transparency mask from a specified color-key
+    ///
+    /// This function sets the alpha value of every pixel matching
+    /// the given color to \a alpha (0 by default), so that they
+    /// become transparent.
+    ///
+    /// \param color Color to make transparent
+    /// \param alpha Alpha value to assign to transparent pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    void createMaskFromColor(const Color& color, Uint8 alpha = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy pixels from another image onto this one
+    ///
+    /// This function does a slow pixel copy and should not be
+    /// used intensively. It can be used to prepare a complex
+    /// static image from several others, but if you need this
+    /// kind of feature in real-time you'd better use sf::RenderTexture.
+    ///
+    /// If \a sourceRect is empty, the whole image is copied.
+    /// If \a applyAlpha is set to true, the transparency of
+    /// source pixels is applied. If it is false, the pixels are
+    /// copied unchanged with their alpha value.
+    ///
+    /// \param source     Source image to copy
+    /// \param destX      X coordinate of the destination position
+    /// \param destY      Y coordinate of the destination position
+    /// \param sourceRect Sub-rectangle of the source image to copy
+    /// \param applyAlpha Should the copy take into account the source transparency?
+    ///
+    ////////////////////////////////////////////////////////////
+    void copy(const Image& source, unsigned int destX, unsigned int destY, const IntRect& sourceRect = IntRect(0, 0, 0, 0), bool applyAlpha = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the color of a pixel
+    ///
+    /// This function doesn't check the validity of the pixel
+    /// coordinates, using out-of-range values will result in
+    /// an undefined behavior.
+    ///
+    /// \param x     X coordinate of pixel to change
+    /// \param y     Y coordinate of pixel to change
+    /// \param color New color of the pixel
+    ///
+    /// \see getPixel
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPixel(unsigned int x, unsigned int y, const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the color of a pixel
+    ///
+    /// This function doesn't check the validity of the pixel
+    /// coordinates, using out-of-range values will result in
+    /// an undefined behavior.
+    ///
+    /// \param x X coordinate of pixel to get
+    /// \param y Y coordinate of pixel to get
+    ///
+    /// \return Color of the pixel at coordinates (x, y)
+    ///
+    /// \see setPixel
+    ///
+    ////////////////////////////////////////////////////////////
+    Color getPixel(unsigned int x, unsigned int y) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a read-only pointer to the array of pixels
+    ///
+    /// The returned value points to an array of RGBA pixels made of
+    /// 8 bits integers components. The size of the array is
+    /// width * height * 4 (getSize().x * getSize().y * 4).
+    /// Warning: the returned pointer may become invalid if you
+    /// modify the image, so you should never store it for too long.
+    /// If the image is empty, a null pointer is returned.
+    ///
+    /// \return Read-only pointer to the array of pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    const Uint8* getPixelsPtr() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Flip the image horizontally (left <-> right)
+    ///
+    ////////////////////////////////////////////////////////////
+    void flipHorizontally();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Flip the image vertically (top <-> bottom)
+    ///
+    ////////////////////////////////////////////////////////////
+    void flipVertically();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Vector2u           m_size;   ///< Image size
+    std::vector<Uint8> m_pixels; ///< Pixels of the image
+};
+
+} // namespace sf
+
+
+#endif // SFML_IMAGE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Image
+/// \ingroup graphics
+///
+/// sf::Image is an abstraction to manipulate images
+/// as bidimensional arrays of pixels. The class provides
+/// functions to load, read, write and save pixels, as well
+/// as many other useful functions.
+///
+/// sf::Image can handle a unique internal representation of
+/// pixels, which is RGBA 32 bits. This means that a pixel
+/// must be composed of 8 bits red, green, blue and alpha
+/// channels -- just like a sf::Color.
+/// All the functions that return an array of pixels follow
+/// this rule, and all parameters that you pass to sf::Image
+/// functions (such as loadFromMemory) must use this
+/// representation as well.
+///
+/// A sf::Image can be copied, but it is a heavy resource and
+/// if possible you should always use [const] references to
+/// pass or return them to avoid useless copies.
+///
+/// Usage example:
+/// \code
+/// // Load an image file from a file
+/// sf::Image background;
+/// if (!background.loadFromFile("background.jpg"))
+///     return -1;
+///
+/// // Create a 20x20 image filled with black color
+/// sf::Image image;
+/// image.create(20, 20, sf::Color::Black);
+///
+/// // Copy image1 on image2 at position (10, 10)
+/// image.copy(background, 10, 10);
+///
+/// // Make the top-left pixel transparent
+/// sf::Color color = image.getPixel(0, 0);
+/// color.a = 0;
+/// image.setPixel(0, 0, color);
+///
+/// // Save the image to a file
+/// if (!image.saveToFile("result.png"))
+///     return -1;
+/// \endcode
+///
+/// \see sf::Texture
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/PrimitiveType.hpp
+++ b/libs/include/SFML/Graphics/PrimitiveType.hpp
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_PRIMITIVETYPE_HPP
+#define SFML_PRIMITIVETYPE_HPP
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \ingroup graphics
+/// \brief Types of primitives that a sf::VertexArray can render
+///
+/// Points and lines have no area, therefore their thickness
+/// will always be 1 pixel, regardless the current transform
+/// and view.
+///
+////////////////////////////////////////////////////////////
+enum PrimitiveType
+{
+    Points,        ///< List of individual points
+    Lines,         ///< List of individual lines
+    LineStrip,     ///< List of connected lines, a point uses the previous point to form a line
+    Triangles,     ///< List of individual triangles
+    TriangleStrip, ///< List of connected triangles, a point uses the two previous points to form a triangle
+    TriangleFan,   ///< List of connected triangles, a point uses the common center and the previous point to form a triangle
+    Quads,         ///< List of individual quads (deprecated, don't work with OpenGL ES)
+
+    // Deprecated names
+    LinesStrip     = LineStrip,     ///< \deprecated Use LineStrip instead
+    TrianglesStrip = TriangleStrip, ///< \deprecated Use TriangleStrip instead
+    TrianglesFan   = TriangleFan    ///< \deprecated Use TriangleFan instead
+};
+
+} // namespace sf
+
+
+#endif // SFML_PRIMITIVETYPE_HPP

--- a/libs/include/SFML/Graphics/Rect.hpp
+++ b/libs/include/SFML/Graphics/Rect.hpp
@@ -1,0 +1,254 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_RECT_HPP
+#define SFML_RECT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Vector2.hpp>
+#include <algorithm>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Utility class for manipulating 2D axis aligned rectangles
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+class Rect
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty rectangle (it is equivalent to calling
+    /// Rect(0, 0, 0, 0)).
+    ///
+    ////////////////////////////////////////////////////////////
+    Rect();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the rectangle from its coordinates
+    ///
+    /// Be careful, the last two parameters are the width
+    /// and height, not the right and bottom coordinates!
+    ///
+    /// \param rectLeft   Left coordinate of the rectangle
+    /// \param rectTop    Top coordinate of the rectangle
+    /// \param rectWidth  Width of the rectangle
+    /// \param rectHeight Height of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    Rect(T rectLeft, T rectTop, T rectWidth, T rectHeight);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the rectangle from position and size
+    ///
+    /// Be careful, the last parameter is the size,
+    /// not the bottom-right corner!
+    ///
+    /// \param position Position of the top-left corner of the rectangle
+    /// \param size     Size of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    Rect(const Vector2<T>& position, const Vector2<T>& size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the rectangle from another type of rectangle
+    ///
+    /// This constructor doesn't replace the copy constructor,
+    /// it's called only when U != T.
+    /// A call to this constructor will fail to compile if U
+    /// is not convertible to T.
+    ///
+    /// \param rectangle Rectangle to convert
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename U>
+    explicit Rect(const Rect<U>& rectangle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a point is inside the rectangle's area
+    ///
+    /// This check is non-inclusive. If the point lies on the
+    /// edge of the rectangle, this function will return false.
+    ///
+    /// \param x X coordinate of the point to test
+    /// \param y Y coordinate of the point to test
+    ///
+    /// \return True if the point is inside, false otherwise
+    ///
+    /// \see intersects
+    ///
+    ////////////////////////////////////////////////////////////
+    bool contains(T x, T y) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a point is inside the rectangle's area
+    ///
+    /// This check is non-inclusive. If the point lies on the
+    /// edge of the rectangle, this function will return false.
+    ///
+    /// \param point Point to test
+    ///
+    /// \return True if the point is inside, false otherwise
+    ///
+    /// \see intersects
+    ///
+    ////////////////////////////////////////////////////////////
+    bool contains(const Vector2<T>& point) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check the intersection between two rectangles
+    ///
+    /// \param rectangle Rectangle to test
+    ///
+    /// \return True if rectangles overlap, false otherwise
+    ///
+    /// \see contains
+    ///
+    ////////////////////////////////////////////////////////////
+    bool intersects(const Rect<T>& rectangle) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check the intersection between two rectangles
+    ///
+    /// This overload returns the overlapped rectangle in the
+    /// \a intersection parameter.
+    ///
+    /// \param rectangle    Rectangle to test
+    /// \param intersection Rectangle to be filled with the intersection
+    ///
+    /// \return True if rectangles overlap, false otherwise
+    ///
+    /// \see contains
+    ///
+    ////////////////////////////////////////////////////////////
+    bool intersects(const Rect<T>& rectangle, Rect<T>& intersection) const;
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    T left;   ///< Left coordinate of the rectangle
+    T top;    ///< Top coordinate of the rectangle
+    T width;  ///< Width of the rectangle
+    T height; ///< Height of the rectangle
+};
+
+////////////////////////////////////////////////////////////
+/// \relates Rect
+/// \brief Overload of binary operator ==
+///
+/// This operator compares strict equality between two rectangles.
+///
+/// \param left  Left operand (a rectangle)
+/// \param right Right operand (a rectangle)
+///
+/// \return True if \a left is equal to \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+bool operator ==(const Rect<T>& left, const Rect<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Rect
+/// \brief Overload of binary operator !=
+///
+/// This operator compares strict difference between two rectangles.
+///
+/// \param left  Left operand (a rectangle)
+/// \param right Right operand (a rectangle)
+///
+/// \return True if \a left is not equal to \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+bool operator !=(const Rect<T>& left, const Rect<T>& right);
+
+#include <SFML/Graphics/Rect.inl>
+
+// Create typedefs for the most common types
+typedef Rect<int>   IntRect;
+typedef Rect<float> FloatRect;
+
+} // namespace sf
+
+
+#endif // SFML_RECT_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Rect
+/// \ingroup graphics
+///
+/// A rectangle is defined by its top-left corner and its size.
+/// It is a very simple class defined for convenience, so
+/// its member variables (left, top, width and height) are public
+/// and can be accessed directly, just like the vector classes
+/// (Vector2 and Vector3).
+///
+/// To keep things simple, sf::Rect doesn't define
+/// functions to emulate the properties that are not directly
+/// members (such as right, bottom, center, etc.), it rather
+/// only provides intersection functions.
+///
+/// sf::Rect uses the usual rules for its boundaries:
+/// \li The left and top edges are included in the rectangle's area
+/// \li The right (left + width) and bottom (top + height) edges are excluded from the rectangle's area
+///
+/// This means that sf::IntRect(0, 0, 1, 1) and sf::IntRect(1, 1, 1, 1)
+/// don't intersect.
+///
+/// sf::Rect is a template and may be used with any numeric type, but
+/// for simplicity the instantiations used by SFML are typedef'd:
+/// \li sf::Rect<int> is sf::IntRect
+/// \li sf::Rect<float> is sf::FloatRect
+///
+/// So that you don't have to care about the template syntax.
+///
+/// Usage example:
+/// \code
+/// // Define a rectangle, located at (0, 0) with a size of 20x5
+/// sf::IntRect r1(0, 0, 20, 5);
+///
+/// // Define another rectangle, located at (4, 2) with a size of 18x10
+/// sf::Vector2i position(4, 2);
+/// sf::Vector2i size(18, 10);
+/// sf::IntRect r2(position, size);
+///
+/// // Test intersections with the point (3, 1)
+/// bool b1 = r1.contains(3, 1); // true
+/// bool b2 = r2.contains(3, 1); // false
+///
+/// // Test the intersection between r1 and r2
+/// sf::IntRect result;
+/// bool b3 = r1.intersects(r2, result); // true
+/// // result == (4, 2, 16, 3)
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Rect.inl
+++ b/libs/include/SFML/Graphics/Rect.inl
@@ -1,0 +1,159 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+Rect<T>::Rect() :
+left  (0),
+top   (0),
+width (0),
+height(0)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+Rect<T>::Rect(T rectLeft, T rectTop, T rectWidth, T rectHeight) :
+left  (rectLeft),
+top   (rectTop),
+width (rectWidth),
+height(rectHeight)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+Rect<T>::Rect(const Vector2<T>& position, const Vector2<T>& size) :
+left  (position.x),
+top   (position.y),
+width (size.x),
+height(size.y)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+template <typename U>
+Rect<T>::Rect(const Rect<U>& rectangle) :
+left  (static_cast<T>(rectangle.left)),
+top   (static_cast<T>(rectangle.top)),
+width (static_cast<T>(rectangle.width)),
+height(static_cast<T>(rectangle.height))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+bool Rect<T>::contains(T x, T y) const
+{
+    // Rectangles with negative dimensions are allowed, so we must handle them correctly
+
+    // Compute the real min and max of the rectangle on both axes
+    T minX = std::min(left, static_cast<T>(left + width));
+    T maxX = std::max(left, static_cast<T>(left + width));
+    T minY = std::min(top, static_cast<T>(top + height));
+    T maxY = std::max(top, static_cast<T>(top + height));
+
+    return (x >= minX) && (x < maxX) && (y >= minY) && (y < maxY);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+bool Rect<T>::contains(const Vector2<T>& point) const
+{
+    return contains(point.x, point.y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+bool Rect<T>::intersects(const Rect<T>& rectangle) const
+{
+    Rect<T> intersection;
+    return intersects(rectangle, intersection);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+bool Rect<T>::intersects(const Rect<T>& rectangle, Rect<T>& intersection) const
+{
+    // Rectangles with negative dimensions are allowed, so we must handle them correctly
+
+    // Compute the min and max of the first rectangle on both axes
+    T r1MinX = std::min(left, static_cast<T>(left + width));
+    T r1MaxX = std::max(left, static_cast<T>(left + width));
+    T r1MinY = std::min(top, static_cast<T>(top + height));
+    T r1MaxY = std::max(top, static_cast<T>(top + height));
+
+    // Compute the min and max of the second rectangle on both axes
+    T r2MinX = std::min(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
+    T r2MaxX = std::max(rectangle.left, static_cast<T>(rectangle.left + rectangle.width));
+    T r2MinY = std::min(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
+    T r2MaxY = std::max(rectangle.top, static_cast<T>(rectangle.top + rectangle.height));
+
+    // Compute the intersection boundaries
+    T interLeft   = std::max(r1MinX, r2MinX);
+    T interTop    = std::max(r1MinY, r2MinY);
+    T interRight  = std::min(r1MaxX, r2MaxX);
+    T interBottom = std::min(r1MaxY, r2MaxY);
+
+    // If the intersection is valid (positive non zero area), then there is an intersection
+    if ((interLeft < interRight) && (interTop < interBottom))
+    {
+        intersection = Rect<T>(interLeft, interTop, interRight - interLeft, interBottom - interTop);
+        return true;
+    }
+    else
+    {
+        intersection = Rect<T>(0, 0, 0, 0);
+        return false;
+    }
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline bool operator ==(const Rect<T>& left, const Rect<T>& right)
+{
+    return (left.left == right.left) && (left.width == right.width) &&
+           (left.top == right.top) && (left.height == right.height);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline bool operator !=(const Rect<T>& left, const Rect<T>& right)
+{
+    return !(left == right);
+}

--- a/libs/include/SFML/Graphics/RectangleShape.hpp
+++ b/libs/include/SFML/Graphics/RectangleShape.hpp
@@ -1,0 +1,132 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_RECTANGLESHAPE_HPP
+#define SFML_RECTANGLESHAPE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Shape.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Specialized shape representing a rectangle
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API RectangleShape : public Shape
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// \param size Size of the rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit RectangleShape(const Vector2f& size = Vector2f(0, 0));
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the size of the rectangle
+    ///
+    /// \param size New size of the rectangle
+    ///
+    /// \see getSize
+    ///
+    ////////////////////////////////////////////////////////////
+    void setSize(const Vector2f& size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the size of the rectangle
+    ///
+    /// \return Size of the rectangle
+    ///
+    /// \see setSize
+    ///
+    ////////////////////////////////////////////////////////////
+    const Vector2f& getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the number of points defining the shape
+    ///
+    /// \return Number of points of the shape. For rectangle
+    ///         shapes, this number is always 4.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual std::size_t getPointCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a point of the rectangle
+    ///
+    /// The returned point is in local coordinates, that is,
+    /// the shape's transforms (position, rotation, scale) are
+    /// not taken into account.
+    /// The result is undefined if \a index is out of the valid range.
+    ///
+    /// \param index Index of the point to get, in range [0 .. 3]
+    ///
+    /// \return index-th point of the shape
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Vector2f getPoint(std::size_t index) const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Vector2f m_size; ///< Size of the rectangle
+};
+
+} // namespace sf
+
+
+#endif // SFML_RECTANGLESHAPE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::RectangleShape
+/// \ingroup graphics
+///
+/// This class inherits all the functions of sf::Transformable
+/// (position, rotation, scale, bounds, ...) as well as the
+/// functions of sf::Shape (outline, color, texture, ...).
+///
+/// Usage example:
+/// \code
+/// sf::RectangleShape rectangle;
+/// rectangle.setSize(sf::Vector2f(100, 50));
+/// rectangle.setOutlineColor(sf::Color::Red);
+/// rectangle.setOutlineThickness(5);
+/// rectangle.setPosition(10, 20);
+/// ...
+/// window.draw(rectangle);
+/// \endcode
+///
+/// \see sf::Shape, sf::CircleShape, sf::ConvexShape
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/RenderStates.hpp
+++ b/libs/include/SFML/Graphics/RenderStates.hpp
@@ -1,0 +1,174 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_RENDERSTATES_HPP
+#define SFML_RENDERSTATES_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/BlendMode.hpp>
+#include <SFML/Graphics/Transform.hpp>
+
+
+namespace sf
+{
+class Shader;
+class Texture;
+
+////////////////////////////////////////////////////////////
+/// \brief Define the states used for drawing to a RenderTarget
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API RenderStates
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Constructing a default set of render states is equivalent
+    /// to using sf::RenderStates::Default.
+    /// The default set defines:
+    /// \li the BlendAlpha blend mode
+    /// \li the identity transform
+    /// \li a null texture
+    /// \li a null shader
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderStates();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a default set of render states with a custom blend mode
+    ///
+    /// \param theBlendMode Blend mode to use
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderStates(const BlendMode& theBlendMode);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a default set of render states with a custom transform
+    ///
+    /// \param theTransform Transform to use
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderStates(const Transform& theTransform);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a default set of render states with a custom texture
+    ///
+    /// \param theTexture Texture to use
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderStates(const Texture* theTexture);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a default set of render states with a custom shader
+    ///
+    /// \param theShader Shader to use
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderStates(const Shader* theShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a set of render states with all its attributes
+    ///
+    /// \param theBlendMode Blend mode to use
+    /// \param theTransform Transform to use
+    /// \param theTexture   Texture to use
+    /// \param theShader    Shader to use
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderStates(const BlendMode& theBlendMode, const Transform& theTransform,
+                 const Texture* theTexture, const Shader* theShader);
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static const RenderStates Default; ///< Special instance holding the default render states
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    BlendMode      blendMode; ///< Blending mode
+    Transform      transform; ///< Transform
+    const Texture* texture;   ///< Texture
+    const Shader*  shader;    ///< Shader
+};
+
+} // namespace sf
+
+
+#endif // SFML_RENDERSTATES_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::RenderStates
+/// \ingroup graphics
+///
+/// There are four global states that can be applied to
+/// the drawn objects:
+/// \li the blend mode: how pixels of the object are blended with the background
+/// \li the transform: how the object is positioned/rotated/scaled
+/// \li the texture: what image is mapped to the object
+/// \li the shader: what custom effect is applied to the object
+///
+/// High-level objects such as sprites or text force some of
+/// these states when they are drawn. For example, a sprite
+/// will set its own texture, so that you don't have to care
+/// about it when drawing the sprite.
+///
+/// The transform is a special case: sprites, texts and shapes
+/// (and it's a good idea to do it with your own drawable classes
+/// too) combine their transform with the one that is passed in the
+/// RenderStates structure. So that you can use a "global" transform
+/// on top of each object's transform.
+///
+/// Most objects, especially high-level drawables, can be drawn
+/// directly without defining render states explicitly -- the
+/// default set of states is ok in most cases.
+/// \code
+/// window.draw(sprite);
+/// \endcode
+///
+/// If you want to use a single specific render state,
+/// for example a shader, you can pass it directly to the Draw
+/// function: sf::RenderStates has an implicit one-argument
+/// constructor for each state.
+/// \code
+/// window.draw(sprite, shader);
+/// \endcode
+///
+/// When you're inside the Draw function of a drawable
+/// object (inherited from sf::Drawable), you can
+/// either pass the render states unmodified, or change
+/// some of them.
+/// For example, a transformable object will combine the
+/// current transform with its own transform. A sprite will
+/// set its texture. Etc.
+///
+/// \see sf::RenderTarget, sf::Drawable
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/RenderTarget.hpp
+++ b/libs/include/SFML/Graphics/RenderTarget.hpp
@@ -1,0 +1,510 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_RENDERTARGET_HPP
+#define SFML_RENDERTARGET_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Color.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/Graphics/View.hpp>
+#include <SFML/Graphics/Transform.hpp>
+#include <SFML/Graphics/BlendMode.hpp>
+#include <SFML/Graphics/RenderStates.hpp>
+#include <SFML/Graphics/PrimitiveType.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+#include <SFML/System/NonCopyable.hpp>
+
+
+namespace sf
+{
+class Drawable;
+class VertexBuffer;
+
+////////////////////////////////////////////////////////////
+/// \brief Base class for all render targets (window, texture, ...)
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API RenderTarget : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~RenderTarget();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clear the entire target with a single color
+    ///
+    /// This function is usually called once every frame,
+    /// to clear the previous contents of the target.
+    ///
+    /// \param color Fill color to use to clear the render target
+    ///
+    ////////////////////////////////////////////////////////////
+    void clear(const Color& color = Color(0, 0, 0, 255));
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current active view
+    ///
+    /// The view is like a 2D camera, it controls which part of
+    /// the 2D scene is visible, and how it is viewed in the
+    /// render target.
+    /// The new view will affect everything that is drawn, until
+    /// another view is set.
+    /// The render target keeps its own copy of the view object,
+    /// so it is not necessary to keep the original one alive
+    /// after calling this function.
+    /// To restore the original view of the target, you can pass
+    /// the result of getDefaultView() to this function.
+    ///
+    /// \param view New view to use
+    ///
+    /// \see getView, getDefaultView
+    ///
+    ////////////////////////////////////////////////////////////
+    void setView(const View& view);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the view currently in use in the render target
+    ///
+    /// \return The view object that is currently used
+    ///
+    /// \see setView, getDefaultView
+    ///
+    ////////////////////////////////////////////////////////////
+    const View& getView() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the default view of the render target
+    ///
+    /// The default view has the initial size of the render target,
+    /// and never changes after the target has been created.
+    ///
+    /// \return The default view of the render target
+    ///
+    /// \see setView, getView
+    ///
+    ////////////////////////////////////////////////////////////
+    const View& getDefaultView() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the viewport of a view, applied to this render target
+    ///
+    /// The viewport is defined in the view as a ratio, this function
+    /// simply applies this ratio to the current dimensions of the
+    /// render target to calculate the pixels rectangle that the viewport
+    /// actually covers in the target.
+    ///
+    /// \param view The view for which we want to compute the viewport
+    ///
+    /// \return Viewport rectangle, expressed in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    IntRect getViewport(const View& view) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a point from target coordinates to world
+    ///        coordinates, using the current view
+    ///
+    /// This function is an overload of the mapPixelToCoords
+    /// function that implicitly uses the current view.
+    /// It is equivalent to:
+    /// \code
+    /// target.mapPixelToCoords(point, target.getView());
+    /// \endcode
+    ///
+    /// \param point Pixel to convert
+    ///
+    /// \return The converted point, in "world" coordinates
+    ///
+    /// \see mapCoordsToPixel
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2f mapPixelToCoords(const Vector2i& point) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a point from target coordinates to world coordinates
+    ///
+    /// This function finds the 2D position that matches the
+    /// given pixel of the render target. In other words, it does
+    /// the inverse of what the graphics card does, to find the
+    /// initial position of a rendered pixel.
+    ///
+    /// Initially, both coordinate systems (world units and target pixels)
+    /// match perfectly. But if you define a custom view or resize your
+    /// render target, this assertion is not true anymore, i.e. a point
+    /// located at (10, 50) in your render target may map to the point
+    /// (150, 75) in your 2D world -- if the view is translated by (140, 25).
+    ///
+    /// For render-windows, this function is typically used to find
+    /// which point (or object) is located below the mouse cursor.
+    ///
+    /// This version uses a custom view for calculations, see the other
+    /// overload of the function if you want to use the current view of the
+    /// render target.
+    ///
+    /// \param point Pixel to convert
+    /// \param view The view to use for converting the point
+    ///
+    /// \return The converted point, in "world" units
+    ///
+    /// \see mapCoordsToPixel
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2f mapPixelToCoords(const Vector2i& point, const View& view) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a point from world coordinates to target
+    ///        coordinates, using the current view
+    ///
+    /// This function is an overload of the mapCoordsToPixel
+    /// function that implicitly uses the current view.
+    /// It is equivalent to:
+    /// \code
+    /// target.mapCoordsToPixel(point, target.getView());
+    /// \endcode
+    ///
+    /// \param point Point to convert
+    ///
+    /// \return The converted point, in target coordinates (pixels)
+    ///
+    /// \see mapPixelToCoords
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2i mapCoordsToPixel(const Vector2f& point) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a point from world coordinates to target coordinates
+    ///
+    /// This function finds the pixel of the render target that matches
+    /// the given 2D point. In other words, it goes through the same process
+    /// as the graphics card, to compute the final position of a rendered point.
+    ///
+    /// Initially, both coordinate systems (world units and target pixels)
+    /// match perfectly. But if you define a custom view or resize your
+    /// render target, this assertion is not true anymore, i.e. a point
+    /// located at (150, 75) in your 2D world may map to the pixel
+    /// (10, 50) of your render target -- if the view is translated by (140, 25).
+    ///
+    /// This version uses a custom view for calculations, see the other
+    /// overload of the function if you want to use the current view of the
+    /// render target.
+    ///
+    /// \param point Point to convert
+    /// \param view The view to use for converting the point
+    ///
+    /// \return The converted point, in target coordinates (pixels)
+    ///
+    /// \see mapPixelToCoords
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2i mapCoordsToPixel(const Vector2f& point, const View& view) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw a drawable object to the render target
+    ///
+    /// \param drawable Object to draw
+    /// \param states   Render states to use for drawing
+    ///
+    ////////////////////////////////////////////////////////////
+    void draw(const Drawable& drawable, const RenderStates& states = RenderStates::Default);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw primitives defined by an array of vertices
+    ///
+    /// \param vertices    Pointer to the vertices
+    /// \param vertexCount Number of vertices in the array
+    /// \param type        Type of primitives to draw
+    /// \param states      Render states to use for drawing
+    ///
+    ////////////////////////////////////////////////////////////
+    void draw(const Vertex* vertices, std::size_t vertexCount,
+              PrimitiveType type, const RenderStates& states = RenderStates::Default);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw primitives defined by a vertex buffer
+    ///
+    /// \param vertexBuffer Vertex buffer
+    /// \param states       Render states to use for drawing
+    ///
+    ////////////////////////////////////////////////////////////
+    void draw(const VertexBuffer& vertexBuffer, const RenderStates& states = RenderStates::Default);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw primitives defined by a vertex buffer
+    ///
+    /// \param vertexBuffer Vertex buffer
+    /// \param firstVertex  Index of the first vertex to render
+    /// \param vertexCount  Number of vertices to render
+    /// \param states       Render states to use for drawing
+    ///
+    ////////////////////////////////////////////////////////////
+    void draw(const VertexBuffer& vertexBuffer, std::size_t firstVertex, std::size_t vertexCount, const RenderStates& states = RenderStates::Default);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the size of the rendering region of the target
+    ///
+    /// \return Size in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Vector2u getSize() const = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Activate or deactivate the render target for rendering
+    ///
+    /// This function makes the render target's context current for
+    /// future OpenGL rendering operations (so you shouldn't care
+    /// about it if you're not doing direct OpenGL stuff).
+    /// A render target's context is active only on the current thread,
+    /// if you want to make it active on another thread you have
+    /// to deactivate it on the previous thread first if it was active.
+    /// Only one context can be current in a thread, so if you
+    /// want to draw OpenGL geometry to another render target
+    /// don't forget to activate it again. Activating a render
+    /// target will automatically deactivate the previously active
+    /// context (if any).
+    ///
+    /// \param active True to activate, false to deactivate
+    ///
+    /// \return True if operation was successful, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual bool setActive(bool active = true);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Save the current OpenGL render states and matrices
+    ///
+    /// This function can be used when you mix SFML drawing
+    /// and direct OpenGL rendering. Combined with popGLStates,
+    /// it ensures that:
+    /// \li SFML's internal states are not messed up by your OpenGL code
+    /// \li your OpenGL states are not modified by a call to a SFML function
+    ///
+    /// More specifically, it must be used around code that
+    /// calls Draw functions. Example:
+    /// \code
+    /// // OpenGL code here...
+    /// window.pushGLStates();
+    /// window.draw(...);
+    /// window.draw(...);
+    /// window.popGLStates();
+    /// // OpenGL code here...
+    /// \endcode
+    ///
+    /// Note that this function is quite expensive: it saves all the
+    /// possible OpenGL states and matrices, even the ones you
+    /// don't care about. Therefore it should be used wisely.
+    /// It is provided for convenience, but the best results will
+    /// be achieved if you handle OpenGL states yourself (because
+    /// you know which states have really changed, and need to be
+    /// saved and restored). Take a look at the resetGLStates
+    /// function if you do so.
+    ///
+    /// \see popGLStates
+    ///
+    ////////////////////////////////////////////////////////////
+    void pushGLStates();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Restore the previously saved OpenGL render states and matrices
+    ///
+    /// See the description of pushGLStates to get a detailed
+    /// description of these functions.
+    ///
+    /// \see pushGLStates
+    ///
+    ////////////////////////////////////////////////////////////
+    void popGLStates();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Reset the internal OpenGL states so that the target is ready for drawing
+    ///
+    /// This function can be used when you mix SFML drawing
+    /// and direct OpenGL rendering, if you choose not to use
+    /// pushGLStates/popGLStates. It makes sure that all OpenGL
+    /// states needed by SFML are set, so that subsequent draw()
+    /// calls will work as expected.
+    ///
+    /// Example:
+    /// \code
+    /// // OpenGL code here...
+    /// glPushAttrib(...);
+    /// window.resetGLStates();
+    /// window.draw(...);
+    /// window.draw(...);
+    /// glPopAttrib(...);
+    /// // OpenGL code here...
+    /// \endcode
+    ///
+    ////////////////////////////////////////////////////////////
+    void resetGLStates();
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderTarget();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Performs the common initialization step after creation
+    ///
+    /// The derived classes must call this function after the
+    /// target is created and ready for drawing.
+    ///
+    ////////////////////////////////////////////////////////////
+    void initialize();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Apply the current view
+    ///
+    ////////////////////////////////////////////////////////////
+    void applyCurrentView();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Apply a new blending mode
+    ///
+    /// \param mode Blending mode to apply
+    ///
+    ////////////////////////////////////////////////////////////
+    void applyBlendMode(const BlendMode& mode);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Apply a new transform
+    ///
+    /// \param transform Transform to apply
+    ///
+    ////////////////////////////////////////////////////////////
+    void applyTransform(const Transform& transform);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Apply a new texture
+    ///
+    /// \param texture Texture to apply
+    ///
+    ////////////////////////////////////////////////////////////
+    void applyTexture(const Texture* texture);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Apply a new shader
+    ///
+    /// \param shader Shader to apply
+    ///
+    ////////////////////////////////////////////////////////////
+    void applyShader(const Shader* shader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Setup environment for drawing
+    ///
+    /// \param useVertexCache Are we going to use the vertex cache?
+    /// \param states         Render states to use for drawing
+    ///
+    ////////////////////////////////////////////////////////////
+    void setupDraw(bool useVertexCache, const RenderStates& states);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw the primitives
+    ///
+    /// \param type        Type of primitives to draw
+    /// \param firstVertex Index of the first vertex to use when drawing
+    /// \param vertexCount Number of vertices to use when drawing
+    ///
+    ////////////////////////////////////////////////////////////
+    void drawPrimitives(PrimitiveType type, std::size_t firstVertex, std::size_t vertexCount);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clean up environment after drawing
+    ///
+    /// \param states Render states used for drawing
+    ///
+    ////////////////////////////////////////////////////////////
+    void cleanupDraw(const RenderStates& states);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Render states cache
+    ///
+    ////////////////////////////////////////////////////////////
+    struct StatesCache
+    {
+        enum {VertexCacheSize = 4};
+
+        bool      enable;         ///< Is the cache enabled?
+        bool      glStatesSet;    ///< Are our internal GL states set yet?
+        bool      viewChanged;    ///< Has the current view changed since last draw?
+        BlendMode lastBlendMode;  ///< Cached blending mode
+        Uint64    lastTextureId;  ///< Cached texture
+        bool      texCoordsArrayEnabled; ///< Is GL_TEXTURE_COORD_ARRAY client state enabled?
+        bool      useVertexCache; ///< Did we previously use the vertex cache?
+        Vertex    vertexCache[VertexCacheSize]; ///< Pre-transformed vertices cache
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    View        m_defaultView; ///< Default view
+    View        m_view;        ///< Current view
+    StatesCache m_cache;       ///< Render states cache
+    Uint64      m_id;          ///< Unique number that identifies the RenderTarget
+};
+
+} // namespace sf
+
+
+#endif // SFML_RENDERTARGET_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::RenderTarget
+/// \ingroup graphics
+///
+/// sf::RenderTarget defines the common behavior of all the
+/// 2D render targets usable in the graphics module. It makes
+/// it possible to draw 2D entities like sprites, shapes, text
+/// without using any OpenGL command directly.
+///
+/// A sf::RenderTarget is also able to use views (sf::View),
+/// which are a kind of 2D cameras. With views you can globally
+/// scroll, rotate or zoom everything that is drawn,
+/// without having to transform every single entity. See the
+/// documentation of sf::View for more details and sample pieces of
+/// code about this class.
+///
+/// On top of that, render targets are still able to render direct
+/// OpenGL stuff. It is even possible to mix together OpenGL calls
+/// and regular SFML drawing commands. When doing so, make sure that
+/// OpenGL states are not messed up by calling the
+/// pushGLStates/popGLStates functions.
+///
+/// \see sf::RenderWindow, sf::RenderTexture, sf::View
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/RenderTexture.hpp
+++ b/libs/include/SFML/Graphics/RenderTexture.hpp
@@ -1,0 +1,314 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_RENDERTEXTURE_HPP
+#define SFML_RENDERTEXTURE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Texture.hpp>
+#include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Window/ContextSettings.hpp>
+
+
+namespace sf
+{
+namespace priv
+{
+    class RenderTextureImpl;
+}
+
+////////////////////////////////////////////////////////////
+/// \brief Target for off-screen 2D rendering into a texture
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API RenderTexture : public RenderTarget
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Constructs an empty, invalid render-texture. You must
+    /// call create to have a valid render-texture.
+    ///
+    /// \see create
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderTexture();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~RenderTexture();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the render-texture
+    ///
+    /// Before calling this function, the render-texture is in
+    /// an invalid state, thus it is mandatory to call it before
+    /// doing anything with the render-texture.
+    /// The last parameter, \a depthBuffer, is useful if you want
+    /// to use the render-texture for 3D OpenGL rendering that requires
+    /// a depth buffer. Otherwise it is unnecessary, and you should
+    /// leave this parameter to false (which is its default value).
+    ///
+    /// \param width       Width of the render-texture
+    /// \param height      Height of the render-texture
+    /// \param depthBuffer Do you want this render-texture to have a depth buffer?
+    ///
+    /// \return True if creation has been successful
+    ///
+    /// \deprecated Use create(unsigned int, unsigned int, const ContextSettings&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED bool create(unsigned int width, unsigned int height, bool depthBuffer);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the render-texture
+    ///
+    /// Before calling this function, the render-texture is in
+    /// an invalid state, thus it is mandatory to call it before
+    /// doing anything with the render-texture.
+    /// The last parameter, \a settings, is useful if you want to enable
+    /// multi-sampling or use the render-texture for OpenGL rendering that
+    /// requires a depth or stencil buffer. Otherwise it is unnecessary, and
+    /// you should leave this parameter at its default value.
+    ///
+    /// \param width    Width of the render-texture
+    /// \param height   Height of the render-texture
+    /// \param settings Additional settings for the underlying OpenGL texture and context
+    ///
+    /// \return True if creation has been successful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool create(unsigned int width, unsigned int height, const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the maximum anti-aliasing level supported by the system
+    ///
+    /// \return The maximum anti-aliasing level supported by the system
+    ///
+    ////////////////////////////////////////////////////////////
+    static unsigned int getMaximumAntialiasingLevel();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable texture smoothing
+    ///
+    /// This function is similar to Texture::setSmooth.
+    /// This parameter is disabled by default.
+    ///
+    /// \param smooth True to enable smoothing, false to disable it
+    ///
+    /// \see isSmooth
+    ///
+    ////////////////////////////////////////////////////////////
+    void setSmooth(bool smooth);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the smooth filtering is enabled or not
+    ///
+    /// \return True if texture smoothing is enabled
+    ///
+    /// \see setSmooth
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isSmooth() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable texture repeating
+    ///
+    /// This function is similar to Texture::setRepeated.
+    /// This parameter is disabled by default.
+    ///
+    /// \param repeated True to enable repeating, false to disable it
+    ///
+    /// \see isRepeated
+    ///
+    ////////////////////////////////////////////////////////////
+    void setRepeated(bool repeated);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the texture is repeated or not
+    ///
+    /// \return True if texture is repeated
+    ///
+    /// \see setRepeated
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isRepeated() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Generate a mipmap using the current texture data
+    ///
+    /// This function is similar to Texture::generateMipmap and operates
+    /// on the texture used as the target for drawing.
+    /// Be aware that any draw operation may modify the base level image data.
+    /// For this reason, calling this function only makes sense after all
+    /// drawing is completed and display has been called. Not calling display
+    /// after subsequent drawing will lead to undefined behavior if a mipmap
+    /// had been previously generated.
+    ///
+    /// \return True if mipmap generation was successful, false if unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool generateMipmap();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Activate or deactivate the render-texture for rendering
+    ///
+    /// This function makes the render-texture's context current for
+    /// future OpenGL rendering operations (so you shouldn't care
+    /// about it if you're not doing direct OpenGL stuff).
+    /// Only one context can be current in a thread, so if you
+    /// want to draw OpenGL geometry to another render target
+    /// (like a RenderWindow) don't forget to activate it again.
+    ///
+    /// \param active True to activate, false to deactivate
+    ///
+    /// \return True if operation was successful, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool setActive(bool active = true);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the contents of the target texture
+    ///
+    /// This function updates the target texture with what
+    /// has been drawn so far. Like for windows, calling this
+    /// function is mandatory at the end of rendering. Not calling
+    /// it may leave the texture in an undefined state.
+    ///
+    ////////////////////////////////////////////////////////////
+    void display();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the size of the rendering region of the texture
+    ///
+    /// The returned value is the size that you passed to
+    /// the create function.
+    ///
+    /// \return Size in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Vector2u getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a read-only reference to the target texture
+    ///
+    /// After drawing to the render-texture and calling Display,
+    /// you can retrieve the updated texture using this function,
+    /// and draw it using a sprite (for example).
+    /// The internal sf::Texture of a render-texture is always the
+    /// same instance, so that it is possible to call this function
+    /// once and keep a reference to the texture even after it is
+    /// modified.
+    ///
+    /// \return Const reference to the texture
+    ///
+    ////////////////////////////////////////////////////////////
+    const Texture& getTexture() const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    priv::RenderTextureImpl* m_impl;    ///< Platform/hardware specific implementation
+    Texture                  m_texture; ///< Target texture to draw on
+};
+
+} // namespace sf
+
+
+#endif // SFML_RENDERTEXTURE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::RenderTexture
+/// \ingroup graphics
+///
+/// sf::RenderTexture is the little brother of sf::RenderWindow.
+/// It implements the same 2D drawing and OpenGL-related functions
+/// (see their base class sf::RenderTarget for more details),
+/// the difference is that the result is stored in an off-screen
+/// texture rather than being show in a window.
+///
+/// Rendering to a texture can be useful in a variety of situations:
+/// \li precomputing a complex static texture (like a level's background from multiple tiles)
+/// \li applying post-effects to the whole scene with shaders
+/// \li creating a sprite from a 3D object rendered with OpenGL
+/// \li etc.
+///
+/// Usage example:
+///
+/// \code
+/// // Create a new render-window
+/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+///
+/// // Create a new render-texture
+/// sf::RenderTexture texture;
+/// if (!texture.create(500, 500))
+///     return -1;
+///
+/// // The main loop
+/// while (window.isOpen())
+/// {
+///    // Event processing
+///    // ...
+///
+///    // Clear the whole texture with red color
+///    texture.clear(sf::Color::Red);
+///
+///    // Draw stuff to the texture
+///    texture.draw(sprite);  // sprite is a sf::Sprite
+///    texture.draw(shape);   // shape is a sf::Shape
+///    texture.draw(text);    // text is a sf::Text
+///
+///    // We're done drawing to the texture
+///    texture.display();
+///
+///    // Now we start rendering to the window, clear it first
+///    window.clear();
+///
+///    // Draw the texture
+///    sf::Sprite sprite(texture.getTexture());
+///    window.draw(sprite);
+///
+///    // End the current frame and display its contents on screen
+///    window.display();
+/// }
+/// \endcode
+///
+/// Like sf::RenderWindow, sf::RenderTexture is still able to render direct
+/// OpenGL stuff. It is even possible to mix together OpenGL calls
+/// and regular SFML drawing commands. If you need a depth buffer for
+/// 3D rendering, don't forget to request it when calling RenderTexture::create.
+///
+/// \see sf::RenderTarget, sf::RenderWindow, sf::View, sf::Texture
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/RenderWindow.hpp
+++ b/libs/include/SFML/Graphics/RenderWindow.hpp
@@ -1,0 +1,284 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_RENDERWINDOW_HPP
+#define SFML_RENDERWINDOW_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/RenderTarget.hpp>
+#include <SFML/Graphics/Image.hpp>
+#include <SFML/Window/Window.hpp>
+#include <string>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Window that can serve as a target for 2D drawing
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API RenderWindow : public Window, public RenderTarget
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor doesn't actually create the window,
+    /// use the other constructors or call create() to do so.
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderWindow();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a new window
+    ///
+    /// This constructor creates the window with the size and pixel
+    /// depth defined in \a mode. An optional style can be passed to
+    /// customize the look and behavior of the window (borders,
+    /// title bar, resizable, closable, ...).
+    ///
+    /// The fourth parameter is an optional structure specifying
+    /// advanced OpenGL context settings such as antialiasing,
+    /// depth-buffer bits, etc. You shouldn't care about these
+    /// parameters for a regular usage of the graphics module.
+    ///
+    /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title    Title of the window
+    /// \param style    %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    RenderWindow(VideoMode mode, const String& title, Uint32 style = Style::Default, const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the window from an existing control
+    ///
+    /// Use this constructor if you want to create an SFML
+    /// rendering area into an already existing control.
+    ///
+    /// The second parameter is an optional structure specifying
+    /// advanced OpenGL context settings such as antialiasing,
+    /// depth-buffer bits, etc. You shouldn't care about these
+    /// parameters for a regular usage of the graphics module.
+    ///
+    /// \param handle   Platform-specific handle of the control (\a HWND on
+    ///                 Windows, \a %Window on Linux/FreeBSD, \a NSWindow on OS X)
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit RenderWindow(WindowHandle handle, const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// Closes the window and frees all the resources attached to it.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~RenderWindow();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the size of the rendering region of the window
+    ///
+    /// The size doesn't include the titlebar and borders
+    /// of the window.
+    ///
+    /// \return Size in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Vector2u getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Activate or deactivate the window as the current target
+    ///        for OpenGL rendering
+    ///
+    /// A window is active only on the current thread, if you want to
+    /// make it active on another thread you have to deactivate it
+    /// on the previous thread first if it was active.
+    /// Only one window can be active on a thread at a time, thus
+    /// the window previously active (if any) automatically gets deactivated.
+    /// This is not to be confused with requestFocus().
+    ///
+    /// \param active True to activate, false to deactivate
+    ///
+    /// \return True if operation was successful, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool setActive(bool active = true);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy the current contents of the window to an image
+    ///
+    /// \deprecated
+    /// Use a sf::Texture and its sf::Texture::update(const Window&)
+    /// function and copy its contents into an sf::Image instead.
+    /// \code
+    /// sf::Vector2u windowSize = window.getSize();
+    /// sf::Texture texture;
+    /// texture.create(windowSize.x, windowSize.y);
+    /// texture.update(window);
+    /// sf::Image screenshot = texture.copyToImage();
+    /// \endcode
+    ///
+    /// This is a slow operation, whose main purpose is to make
+    /// screenshots of the application. If you want to update an
+    /// image with the contents of the window and then use it for
+    /// drawing, you should rather use a sf::Texture and its
+    /// update(Window&) function.
+    /// You can also draw things directly to a texture with the
+    /// sf::RenderTexture class.
+    ///
+    /// \return Image containing the captured contents
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED Image capture() const;
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Function called after the window has been created
+    ///
+    /// This function is called so that derived classes can
+    /// perform their own specific initialization as soon as
+    /// the window is created.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onCreate();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Function called after the window has been resized
+    ///
+    /// This function is called so that derived classes can
+    /// perform custom actions when the size of the window changes.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onResize();
+};
+
+} // namespace sf
+
+
+#endif // SFML_RENDERWINDOW_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::RenderWindow
+/// \ingroup graphics
+///
+/// sf::RenderWindow is the main class of the Graphics module.
+/// It defines an OS window that can be painted using the other
+/// classes of the graphics module.
+///
+/// sf::RenderWindow is derived from sf::Window, thus it inherits
+/// all its features: events, window management, OpenGL rendering,
+/// etc. See the documentation of sf::Window for a more complete
+/// description of all these features, as well as code examples.
+///
+/// On top of that, sf::RenderWindow adds more features related to
+/// 2D drawing with the graphics module (see its base class
+/// sf::RenderTarget for more details).
+/// Here is a typical rendering and event loop with a sf::RenderWindow:
+///
+/// \code
+/// // Declare and create a new render-window
+/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML window");
+///
+/// // Limit the framerate to 60 frames per second (this step is optional)
+/// window.setFramerateLimit(60);
+///
+/// // The main loop - ends as soon as the window is closed
+/// while (window.isOpen())
+/// {
+///    // Event processing
+///    sf::Event event;
+///    while (window.pollEvent(event))
+///    {
+///        // Request for closing the window
+///        if (event.type == sf::Event::Closed)
+///            window.close();
+///    }
+///
+///    // Clear the whole window before rendering a new frame
+///    window.clear();
+///
+///    // Draw some graphical entities
+///    window.draw(sprite);
+///    window.draw(circle);
+///    window.draw(text);
+///
+///    // End the current frame and display its contents on screen
+///    window.display();
+/// }
+/// \endcode
+///
+/// Like sf::Window, sf::RenderWindow is still able to render direct
+/// OpenGL stuff. It is even possible to mix together OpenGL calls
+/// and regular SFML drawing commands.
+///
+/// \code
+/// // Create the render window
+/// sf::RenderWindow window(sf::VideoMode(800, 600), "SFML OpenGL");
+///
+/// // Create a sprite and a text to display
+/// sf::Sprite sprite;
+/// sf::Text text;
+/// ...
+///
+/// // Perform OpenGL initializations
+/// glMatrixMode(GL_PROJECTION);
+/// ...
+///
+/// // Start the rendering loop
+/// while (window.isOpen())
+/// {
+///     // Process events
+///     ...
+///
+///     // Draw a background sprite
+///     window.pushGLStates();
+///     window.draw(sprite);
+///     window.popGLStates();
+///
+///     // Draw a 3D object using OpenGL
+///     glBegin(GL_QUADS);
+///         glVertex3f(...);
+///         ...
+///     glEnd();
+///
+///     // Draw text on top of the 3D object
+///     window.pushGLStates();
+///     window.draw(text);
+///     window.popGLStates();
+///
+///     // Finally, display the rendered frame on screen
+///     window.display();
+/// }
+/// \endcode
+///
+/// \see sf::Window, sf::RenderTarget, sf::RenderTexture, sf::View
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Shader.hpp
+++ b/libs/include/SFML/Graphics/Shader.hpp
@@ -1,0 +1,875 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SHADER_HPP
+#define SFML_SHADER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Glsl.hpp>
+#include <SFML/Window/GlResource.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/System/Vector3.hpp>
+#include <map>
+#include <string>
+
+
+namespace sf
+{
+class Color;
+class InputStream;
+class Texture;
+class Transform;
+
+////////////////////////////////////////////////////////////
+/// \brief Shader class (vertex, geometry and fragment)
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Shader : GlResource, NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Types of shaders
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Type
+    {
+        Vertex,   ///< %Vertex shader
+        Geometry, ///< Geometry shader
+        Fragment  ///< Fragment (pixel) shader
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Special type that can be passed to setUniform(),
+    ///        and that represents the texture of the object being drawn
+    ///
+    /// \see setUniform(const std::string&, CurrentTextureType)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct CurrentTextureType {};
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Represents the texture of the object being drawn
+    ///
+    /// \see setUniform(const std::string&, CurrentTextureType)
+    ///
+    ////////////////////////////////////////////////////////////
+    static CurrentTextureType CurrentTexture;
+
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor creates an invalid shader.
+    ///
+    ////////////////////////////////////////////////////////////
+    Shader();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Shader();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a file
+    ///
+    /// This function loads a single shader, vertex, geometry or
+    /// fragment, identified by the second argument.
+    /// The source must be a text file containing a valid
+    /// shader in GLSL language. GLSL is a C-like language
+    /// dedicated to OpenGL shaders; you'll probably need to
+    /// read a good documentation for it before writing your
+    /// own shaders.
+    ///
+    /// \param filename Path of the vertex, geometry or fragment shader file to load
+    /// \param type     Type of shader (vertex, geometry or fragment)
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromFile(const std::string& filename, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from files
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be text files containing valid shaders
+    /// in GLSL language. GLSL is a C-like language dedicated to
+    /// OpenGL shaders; you'll probably need to read a good documentation
+    /// for it before writing your own shaders.
+    ///
+    /// \param vertexShaderFilename   Path of the vertex shader file to load
+    /// \param fragmentShaderFilename Path of the fragment shader file to load
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromFile(const std::string& vertexShaderFilename, const std::string& fragmentShaderFilename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from files
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be text files containing valid shaders
+    /// in GLSL language. GLSL is a C-like language dedicated to
+    /// OpenGL shaders; you'll probably need to read a good documentation
+    /// for it before writing your own shaders.
+    ///
+    /// \param vertexShaderFilename   Path of the vertex shader file to load
+    /// \param geometryShaderFilename Path of the geometry shader file to load
+    /// \param fragmentShaderFilename Path of the fragment shader file to load
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromMemory, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromFile(const std::string& vertexShaderFilename, const std::string& geometryShaderFilename, const std::string& fragmentShaderFilename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a source code in memory
+    ///
+    /// This function loads a single shader, vertex, geometry
+    /// or fragment, identified by the second argument.
+    /// The source code must be a valid shader in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param shader String containing the source code of the shader
+    /// \param type   Type of shader (vertex, geometry or fragment)
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromMemory(const std::string& shader, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from source codes in memory
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be valid shaders in GLSL language. GLSL is
+    /// a C-like language dedicated to OpenGL shaders; you'll
+    /// probably need to read a good documentation for it before
+    /// writing your own shaders.
+    ///
+    /// \param vertexShader   String containing the source code of the vertex shader
+    /// \param fragmentShader String containing the source code of the fragment shader
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromMemory(const std::string& vertexShader, const std::string& fragmentShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from source codes in memory
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The sources must be valid shaders in GLSL language. GLSL is
+    /// a C-like language dedicated to OpenGL shaders; you'll
+    /// probably need to read a good documentation for it before
+    /// writing your own shaders.
+    ///
+    /// \param vertexShader   String containing the source code of the vertex shader
+    /// \param geometryShader String containing the source code of the geometry shader
+    /// \param fragmentShader String containing the source code of the fragment shader
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromStream
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromMemory(const std::string& vertexShader, const std::string& geometryShader, const std::string& fragmentShader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry or fragment shader from a custom stream
+    ///
+    /// This function loads a single shader, vertex, geometry
+    /// or fragment, identified by the second argument.
+    /// The source code must be a valid shader in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for it
+    /// before writing your own shaders.
+    ///
+    /// \param stream Source stream to read from
+    /// \param type   Type of shader (vertex, geometry or fragment)
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromStream(InputStream& stream, Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load both the vertex and fragment shaders from custom streams
+    ///
+    /// This function loads both the vertex and the fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The source codes must be valid shaders in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param vertexShaderStream   Source stream to read the vertex shader from
+    /// \param fragmentShaderStream Source stream to read the fragment shader from
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromStream(InputStream& vertexShaderStream, InputStream& fragmentShaderStream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the vertex, geometry and fragment shaders from custom streams
+    ///
+    /// This function loads the vertex, geometry and fragment
+    /// shaders. If one of them fails to load, the shader is left
+    /// empty (the valid shader is unloaded).
+    /// The source codes must be valid shaders in GLSL language.
+    /// GLSL is a C-like language dedicated to OpenGL shaders;
+    /// you'll probably need to read a good documentation for
+    /// it before writing your own shaders.
+    ///
+    /// \param vertexShaderStream   Source stream to read the vertex shader from
+    /// \param geometryShaderStream Source stream to read the geometry shader from
+    /// \param fragmentShaderStream Source stream to read the fragment shader from
+    ///
+    /// \return True if loading succeeded, false if it failed
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromStream(InputStream& vertexShaderStream, InputStream& geometryShaderStream, InputStream& fragmentShaderStream);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p float uniform
+    ///
+    /// \param name Name of the uniform variable in GLSL
+    /// \param x    Value of the float scalar
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, float x);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p vec2 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the vec2 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Vec2& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p vec3 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the vec3 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Vec3& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p vec4 uniform
+    ///
+    /// This overload can also be called with sf::Color objects
+    /// that are converted to sf::Glsl::Vec4.
+    ///
+    /// It is important to note that the components of the color are
+    /// normalized before being passed to the shader. Therefore,
+    /// they are converted from range [0 .. 255] to range [0 .. 1].
+    /// For example, a sf::Color(255, 127, 0, 255) will be transformed
+    /// to a vec4(1.0, 0.5, 0.0, 1.0) in the shader.
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the vec4 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Vec4& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p int uniform
+    ///
+    /// \param name Name of the uniform variable in GLSL
+    /// \param x    Value of the int scalar
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, int x);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p ivec2 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the ivec2 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Ivec2& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p ivec3 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the ivec3 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Ivec3& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p ivec4 uniform
+    ///
+    /// This overload can also be called with sf::Color objects
+    /// that are converted to sf::Glsl::Ivec4.
+    ///
+    /// If color conversions are used, the ivec4 uniform in GLSL
+    /// will hold the same values as the original sf::Color
+    /// instance. For example, sf::Color(255, 127, 0, 255) is
+    /// mapped to ivec4(255, 127, 0, 255).
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the ivec4 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Ivec4& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p bool uniform
+    ///
+    /// \param name Name of the uniform variable in GLSL
+    /// \param x    Value of the bool scalar
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, bool x);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p bvec2 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the bvec2 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Bvec2& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p bvec3 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the bvec3 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Bvec3& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p bvec4 uniform
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param vector Value of the bvec4 vector
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Bvec4& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p mat3 matrix
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param matrix Value of the mat3 matrix
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Mat3& matrix);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify value for \p mat4 matrix
+    ///
+    /// \param name   Name of the uniform variable in GLSL
+    /// \param matrix Value of the mat4 matrix
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Glsl::Mat4& matrix);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify a texture as \p sampler2D uniform
+    ///
+    /// \a name is the name of the variable to change in the shader.
+    /// The corresponding parameter in the shader must be a 2D texture
+    /// (\p sampler2D GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform sampler2D the_texture; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// sf::Texture texture;
+    /// ...
+    /// shader.setUniform("the_texture", texture);
+    /// \endcode
+    /// It is important to note that \a texture must remain alive as long
+    /// as the shader uses it, no copy is made internally.
+    ///
+    /// To use the texture of the object being drawn, which cannot be
+    /// known in advance, you can pass the special value
+    /// sf::Shader::CurrentTexture:
+    /// \code
+    /// shader.setUniform("the_texture", sf::Shader::CurrentTexture).
+    /// \endcode
+    ///
+    /// \param name    Name of the texture in the shader
+    /// \param texture Texture to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, const Texture& texture);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify current texture as \p sampler2D uniform
+    ///
+    /// This overload maps a shader texture variable to the
+    /// texture of the object being drawn, which cannot be
+    /// known in advance. The second argument must be
+    /// sf::Shader::CurrentTexture.
+    /// The corresponding parameter in the shader must be a 2D texture
+    /// (\p sampler2D GLSL type).
+    ///
+    /// Example:
+    /// \code
+    /// uniform sampler2D current; // this is the variable in the shader
+    /// \endcode
+    /// \code
+    /// shader.setUniform("current", sf::Shader::CurrentTexture);
+    /// \endcode
+    ///
+    /// \param name Name of the texture in the shader
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniform(const std::string& name, CurrentTextureType);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p float[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param scalarArray pointer to array of \p float values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const float* scalarArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p vec2[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param vectorArray pointer to array of \p vec2 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Vec2* vectorArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p vec3[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param vectorArray pointer to array of \p vec3 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Vec3* vectorArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p vec4[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param vectorArray pointer to array of \p vec4 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Vec4* vectorArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p mat3[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param matrixArray pointer to array of \p mat3 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Mat3* matrixArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specify values for \p mat4[] array uniform
+    ///
+    /// \param name        Name of the uniform variable in GLSL
+    /// \param matrixArray pointer to array of \p mat4 values
+    /// \param length      Number of elements in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUniformArray(const std::string& name, const Glsl::Mat4* matrixArray, std::size_t length);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a float parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, float) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, float x);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 2-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec2&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 3-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec3&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y, float z);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 4-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec4&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, float x, float y, float z, float w);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 2-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec2&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Vector2f& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a 3-components vector parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec3&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Vector3f& vector);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a color parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Vec4&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a matrix parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Glsl::Mat4&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Transform& transform);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a texture parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, const Texture&) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, const Texture& texture);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change a texture parameter of the shader
+    ///
+    /// \deprecated Use setUniform(const std::string&, CurrentTextureType) instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setParameter(const std::string& name, CurrentTextureType);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the underlying OpenGL handle of the shader.
+    ///
+    /// You shouldn't need to use this function, unless you have
+    /// very specific stuff to implement that SFML doesn't support,
+    /// or implement a temporary workaround until a bug is fixed.
+    ///
+    /// \return OpenGL handle of the shader or 0 if not yet loaded
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getNativeHandle() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Bind a shader for rendering
+    ///
+    /// This function is not part of the graphics API, it mustn't be
+    /// used when drawing SFML entities. It must be used only if you
+    /// mix sf::Shader with OpenGL code.
+    ///
+    /// \code
+    /// sf::Shader s1, s2;
+    /// ...
+    /// sf::Shader::bind(&s1);
+    /// // draw OpenGL stuff that use s1...
+    /// sf::Shader::bind(&s2);
+    /// // draw OpenGL stuff that use s2...
+    /// sf::Shader::bind(NULL);
+    /// // draw OpenGL stuff that use no shader...
+    /// \endcode
+    ///
+    /// \param shader Shader to bind, can be null to use no shader
+    ///
+    ////////////////////////////////////////////////////////////
+    static void bind(const Shader* shader);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the system supports shaders
+    ///
+    /// This function should always be called before using
+    /// the shader features. If it returns false, then
+    /// any attempt to use sf::Shader will fail.
+    ///
+    /// \return True if shaders are supported, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isAvailable();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the system supports geometry shaders
+    ///
+    /// This function should always be called before using
+    /// the geometry shader features. If it returns false, then
+    /// any attempt to use sf::Shader geometry shader features will fail.
+    ///
+    /// This function can only return true if isAvailable() would also
+    /// return true, since shaders in general have to be supported in
+    /// order for geometry shaders to be supported as well.
+    ///
+    /// Note: The first call to this function, whether by your
+    /// code or SFML will result in a context switch.
+    ///
+    /// \return True if geometry shaders are supported, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isGeometryAvailable();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Compile the shader(s) and create the program
+    ///
+    /// If one of the arguments is NULL, the corresponding shader
+    /// is not created.
+    ///
+    /// \param vertexShaderCode   Source code of the vertex shader
+    /// \param geometryShaderCode Source code of the geometry shader
+    /// \param fragmentShaderCode Source code of the fragment shader
+    ///
+    /// \return True on success, false if any error happened
+    ///
+    ////////////////////////////////////////////////////////////
+    bool compile(const char* vertexShaderCode, const char* geometryShaderCode, const char* fragmentShaderCode);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Bind all the textures used by the shader
+    ///
+    /// This function each texture to a different unit, and
+    /// updates the corresponding variables in the shader accordingly.
+    ///
+    ////////////////////////////////////////////////////////////
+    void bindTextures() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the location ID of a shader uniform
+    ///
+    /// \param name Name of the uniform variable to search
+    ///
+    /// \return Location ID of the uniform, or -1 if not found
+    ///
+    ////////////////////////////////////////////////////////////
+    int getUniformLocation(const std::string& name);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief RAII object to save and restore the program
+    ///        binding while uniforms are being set
+    ///
+    /// Implementation is private in the .cpp file.
+    ///
+    ////////////////////////////////////////////////////////////
+    struct UniformBinder;
+
+    ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::map<int, const Texture*> TextureTable;
+    typedef std::map<std::string, int> UniformTable;
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    unsigned int m_shaderProgram;  ///< OpenGL identifier for the program
+    int          m_currentTexture; ///< Location of the current texture in the shader
+    TextureTable m_textures;       ///< Texture variables in the shader, mapped to their location
+    UniformTable m_uniforms;       ///< Parameters location cache
+};
+
+} // namespace sf
+
+
+#endif // SFML_SHADER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Shader
+/// \ingroup graphics
+///
+/// Shaders are programs written using a specific language,
+/// executed directly by the graphics card and allowing
+/// to apply real-time operations to the rendered entities.
+///
+/// There are three kinds of shaders:
+/// \li %Vertex shaders, that process vertices
+/// \li Geometry shaders, that process primitives
+/// \li Fragment (pixel) shaders, that process pixels
+///
+/// A sf::Shader can be composed of either a vertex shader
+/// alone, a geometry shader alone, a fragment shader alone,
+/// or any combination of them. (see the variants of the
+/// load functions).
+///
+/// Shaders are written in GLSL, which is a C-like
+/// language dedicated to OpenGL shaders. You'll probably
+/// need to learn its basics before writing your own shaders
+/// for SFML.
+///
+/// Like any C/C++ program, a GLSL shader has its own variables
+/// called \a uniforms that you can set from your C++ application.
+/// sf::Shader handles different types of uniforms:
+/// \li scalars: \p float, \p int, \p bool
+/// \li vectors (2, 3 or 4 components)
+/// \li matrices (3x3 or 4x4)
+/// \li samplers (textures)
+///
+/// Some SFML-specific types can be converted:
+/// \li sf::Color as a 4D vector (\p vec4)
+/// \li sf::Transform as matrices (\p mat3 or \p mat4)
+///
+/// Every uniform variable in a shader can be set through one of the
+/// setUniform() or setUniformArray() overloads. For example, if you
+/// have a shader with the following uniforms:
+/// \code
+/// uniform float offset;
+/// uniform vec3 point;
+/// uniform vec4 color;
+/// uniform mat4 matrix;
+/// uniform sampler2D overlay;
+/// uniform sampler2D current;
+/// \endcode
+/// You can set their values from C++ code as follows, using the types
+/// defined in the sf::Glsl namespace:
+/// \code
+/// shader.setUniform("offset", 2.f);
+/// shader.setUniform("point", sf::Vector3f(0.5f, 0.8f, 0.3f));
+/// shader.setUniform("color", sf::Glsl::Vec4(color));          // color is a sf::Color
+/// shader.setUniform("matrix", sf::Glsl::Mat4(transform));     // transform is a sf::Transform
+/// shader.setUniform("overlay", texture);                      // texture is a sf::Texture
+/// shader.setUniform("current", sf::Shader::CurrentTexture);
+/// \endcode
+///
+/// The old setParameter() overloads are deprecated and will be removed in a
+/// future version. You should use their setUniform() equivalents instead.
+///
+/// The special Shader::CurrentTexture argument maps the
+/// given \p sampler2D uniform to the current texture of the
+/// object being drawn (which cannot be known in advance).
+///
+/// To apply a shader to a drawable, you must pass it as an
+/// additional parameter to the \ref RenderWindow::draw function:
+/// \code
+/// window.draw(sprite, &shader);
+/// \endcode
+///
+/// ... which is in fact just a shortcut for this:
+/// \code
+/// sf::RenderStates states;
+/// states.shader = &shader;
+/// window.draw(sprite, states);
+/// \endcode
+///
+/// In the code above we pass a pointer to the shader, because it may
+/// be null (which means "no shader").
+///
+/// Shaders can be used on any drawable, but some combinations are
+/// not interesting. For example, using a vertex shader on a sf::Sprite
+/// is limited because there are only 4 vertices, the sprite would
+/// have to be subdivided in order to apply wave effects.
+/// Another bad example is a fragment shader with sf::Text: the texture
+/// of the text is not the actual text that you see on screen, it is
+/// a big texture containing all the characters of the font in an
+/// arbitrary order; thus, texture lookups on pixels other than the
+/// current one may not give you the expected result.
+///
+/// Shaders can also be used to apply global post-effects to the
+/// current contents of the target (like the old sf::PostFx class
+/// in SFML 1). This can be done in two different ways:
+/// \li draw everything to a sf::RenderTexture, then draw it to
+///     the main target using the shader
+/// \li draw everything directly to the main target, then use
+///     sf::Texture::update(Window&) to copy its contents to a texture
+///     and draw it to the main target using the shader
+///
+/// The first technique is more optimized because it doesn't involve
+/// retrieving the target's pixels to system memory, but the
+/// second one doesn't impact the rendering process and can be
+/// easily inserted anywhere without impacting all the code.
+///
+/// Like sf::Texture that can be used as a raw OpenGL texture,
+/// sf::Shader can also be used directly as a raw shader for
+/// custom OpenGL geometry.
+/// \code
+/// sf::Shader::bind(&shader);
+/// ... render OpenGL geometry ...
+/// sf::Shader::bind(NULL);
+/// \endcode
+///
+/// \see sf::Glsl
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Shape.hpp
+++ b/libs/include/SFML/Graphics/Shape.hpp
@@ -1,0 +1,355 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SHAPE_HPP
+#define SFML_SHAPE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/Transformable.hpp>
+#include <SFML/Graphics/VertexArray.hpp>
+#include <SFML/System/Vector2.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Base class for textured shapes with outline
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Shape : public Drawable, public Transformable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Virtual destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~Shape();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the source texture of the shape
+    ///
+    /// The \a texture argument refers to a texture that must
+    /// exist as long as the shape uses it. Indeed, the shape
+    /// doesn't store its own copy of the texture, but rather keeps
+    /// a pointer to the one that you passed to this function.
+    /// If the source texture is destroyed and the shape tries to
+    /// use it, the behavior is undefined.
+    /// \a texture can be NULL to disable texturing.
+    /// If \a resetRect is true, the TextureRect property of
+    /// the shape is automatically adjusted to the size of the new
+    /// texture. If it is false, the texture rect is left unchanged.
+    ///
+    /// \param texture   New texture
+    /// \param resetRect Should the texture rect be reset to the size of the new texture?
+    ///
+    /// \see getTexture, setTextureRect
+    ///
+    ////////////////////////////////////////////////////////////
+    void setTexture(const Texture* texture, bool resetRect = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the sub-rectangle of the texture that the shape will display
+    ///
+    /// The texture rect is useful when you don't want to display
+    /// the whole texture, but rather a part of it.
+    /// By default, the texture rect covers the entire texture.
+    ///
+    /// \param rect Rectangle defining the region of the texture to display
+    ///
+    /// \see getTextureRect, setTexture
+    ///
+    ////////////////////////////////////////////////////////////
+    void setTextureRect(const IntRect& rect);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the fill color of the shape
+    ///
+    /// This color is modulated (multiplied) with the shape's
+    /// texture if any. It can be used to colorize the shape,
+    /// or change its global opacity.
+    /// You can use sf::Color::Transparent to make the inside of
+    /// the shape transparent, and have the outline alone.
+    /// By default, the shape's fill color is opaque white.
+    ///
+    /// \param color New color of the shape
+    ///
+    /// \see getFillColor, setOutlineColor
+    ///
+    ////////////////////////////////////////////////////////////
+    void setFillColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the outline color of the shape
+    ///
+    /// By default, the shape's outline color is opaque white.
+    ///
+    /// \param color New outline color of the shape
+    ///
+    /// \see getOutlineColor, setFillColor
+    ///
+    ////////////////////////////////////////////////////////////
+    void setOutlineColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the thickness of the shape's outline
+    ///
+    /// Note that negative values are allowed (so that the outline
+    /// expands towards the center of the shape), and using zero
+    /// disables the outline.
+    /// By default, the outline thickness is 0.
+    ///
+    /// \param thickness New outline thickness
+    ///
+    /// \see getOutlineThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    void setOutlineThickness(float thickness);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the source texture of the shape
+    ///
+    /// If the shape has no source texture, a NULL pointer is returned.
+    /// The returned pointer is const, which means that you can't
+    /// modify the texture when you retrieve it with this function.
+    ///
+    /// \return Pointer to the shape's texture
+    ///
+    /// \see setTexture
+    ///
+    ////////////////////////////////////////////////////////////
+    const Texture* getTexture() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the sub-rectangle of the texture displayed by the shape
+    ///
+    /// \return Texture rectangle of the shape
+    ///
+    /// \see setTextureRect
+    ///
+    ////////////////////////////////////////////////////////////
+    const IntRect& getTextureRect() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the fill color of the shape
+    ///
+    /// \return Fill color of the shape
+    ///
+    /// \see setFillColor
+    ///
+    ////////////////////////////////////////////////////////////
+    const Color& getFillColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the outline color of the shape
+    ///
+    /// \return Outline color of the shape
+    ///
+    /// \see setOutlineColor
+    ///
+    ////////////////////////////////////////////////////////////
+    const Color& getOutlineColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the outline thickness of the shape
+    ///
+    /// \return Outline thickness of the shape
+    ///
+    /// \see setOutlineThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    float getOutlineThickness() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the total number of points of the shape
+    ///
+    /// \return Number of points of the shape
+    ///
+    /// \see getPoint
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual std::size_t getPointCount() const = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a point of the shape
+    ///
+    /// The returned point is in local coordinates, that is,
+    /// the shape's transforms (position, rotation, scale) are
+    /// not taken into account.
+    /// The result is undefined if \a index is out of the valid range.
+    ///
+    /// \param index Index of the point to get, in range [0 .. getPointCount() - 1]
+    ///
+    /// \return index-th point of the shape
+    ///
+    /// \see getPointCount
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Vector2f getPoint(std::size_t index) const = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the local bounding rectangle of the entity
+    ///
+    /// The returned rectangle is in local coordinates, which means
+    /// that it ignores the transformations (translation, rotation,
+    /// scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// entity in the entity's coordinate system.
+    ///
+    /// \return Local bounding rectangle of the entity
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getLocalBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the global (non-minimal) bounding rectangle of the entity
+    ///
+    /// The returned rectangle is in global coordinates, which means
+    /// that it takes into account the transformations (translation,
+    /// rotation, scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// shape in the global 2D world's coordinate system.
+    ///
+    /// This function does not necessarily return the \a minimal
+    /// bounding rectangle. It merely ensures that the returned
+    /// rectangle covers all the vertices (but possibly more).
+    /// This allows for a fast approximation of the bounds as a
+    /// first check; you may want to use more precise checks
+    /// on top of that.
+    ///
+    /// \return Global bounding rectangle of the entity
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getGlobalBounds() const;
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Shape();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Recompute the internal geometry of the shape
+    ///
+    /// This function must be called by the derived class everytime
+    /// the shape's points change (i.e. the result of either
+    /// getPointCount or getPoint is different).
+    ///
+    ////////////////////////////////////////////////////////////
+    void update();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw the shape to a render target
+    ///
+    /// \param target Render target to draw to
+    /// \param states Current render states
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void draw(RenderTarget& target, RenderStates states) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the fill vertices' color
+    ///
+    ////////////////////////////////////////////////////////////
+    void updateFillColors();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the fill vertices' texture coordinates
+    ///
+    ////////////////////////////////////////////////////////////
+    void updateTexCoords();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the outline vertices' position
+    ///
+    ////////////////////////////////////////////////////////////
+    void updateOutline();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the outline vertices' color
+    ///
+    ////////////////////////////////////////////////////////////
+    void updateOutlineColors();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    const Texture* m_texture;          ///< Texture of the shape
+    IntRect        m_textureRect;      ///< Rectangle defining the area of the source texture to display
+    Color          m_fillColor;        ///< Fill color
+    Color          m_outlineColor;     ///< Outline color
+    float          m_outlineThickness; ///< Thickness of the shape's outline
+    VertexArray    m_vertices;         ///< Vertex array containing the fill geometry
+    VertexArray    m_outlineVertices;  ///< Vertex array containing the outline geometry
+    FloatRect      m_insideBounds;     ///< Bounding rectangle of the inside (fill)
+    FloatRect      m_bounds;           ///< Bounding rectangle of the whole shape (outline + fill)
+};
+
+} // namespace sf
+
+
+#endif // SFML_SHAPE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Shape
+/// \ingroup graphics
+///
+/// sf::Shape is a drawable class that allows to define and
+/// display a custom convex shape on a render target.
+/// It's only an abstract base, it needs to be specialized for
+/// concrete types of shapes (circle, rectangle, convex polygon,
+/// star, ...).
+///
+/// In addition to the attributes provided by the specialized
+/// shape classes, a shape always has the following attributes:
+/// \li a texture
+/// \li a texture rectangle
+/// \li a fill color
+/// \li an outline color
+/// \li an outline thickness
+///
+/// Each feature is optional, and can be disabled easily:
+/// \li the texture can be null
+/// \li the fill/outline colors can be sf::Color::Transparent
+/// \li the outline thickness can be zero
+///
+/// You can write your own derived shape class, there are only
+/// two virtual functions to override:
+/// \li getPointCount must return the number of points of the shape
+/// \li getPoint must return the points of the shape
+///
+/// \see sf::RectangleShape, sf::CircleShape, sf::ConvexShape, sf::Transformable
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Sprite.hpp
+++ b/libs/include/SFML/Graphics/Sprite.hpp
@@ -1,0 +1,279 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SPRITE_HPP
+#define SFML_SPRITE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/Transformable.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+#include <SFML/Graphics/Rect.hpp>
+
+
+namespace sf
+{
+class Texture;
+
+////////////////////////////////////////////////////////////
+/// \brief Drawable representation of a texture, with its
+///        own transformations, color, etc.
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Sprite : public Drawable, public Transformable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty sprite with no source texture.
+    ///
+    ////////////////////////////////////////////////////////////
+    Sprite();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sprite from a source texture
+    ///
+    /// \param texture Source texture
+    ///
+    /// \see setTexture
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Sprite(const Texture& texture);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the sprite from a sub-rectangle of a source texture
+    ///
+    /// \param texture   Source texture
+    /// \param rectangle Sub-rectangle of the texture to assign to the sprite
+    ///
+    /// \see setTexture, setTextureRect
+    ///
+    ////////////////////////////////////////////////////////////
+    Sprite(const Texture& texture, const IntRect& rectangle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the source texture of the sprite
+    ///
+    /// The \a texture argument refers to a texture that must
+    /// exist as long as the sprite uses it. Indeed, the sprite
+    /// doesn't store its own copy of the texture, but rather keeps
+    /// a pointer to the one that you passed to this function.
+    /// If the source texture is destroyed and the sprite tries to
+    /// use it, the behavior is undefined.
+    /// If \a resetRect is true, the TextureRect property of
+    /// the sprite is automatically adjusted to the size of the new
+    /// texture. If it is false, the texture rect is left unchanged.
+    ///
+    /// \param texture   New texture
+    /// \param resetRect Should the texture rect be reset to the size of the new texture?
+    ///
+    /// \see getTexture, setTextureRect
+    ///
+    ////////////////////////////////////////////////////////////
+    void setTexture(const Texture& texture, bool resetRect = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the sub-rectangle of the texture that the sprite will display
+    ///
+    /// The texture rect is useful when you don't want to display
+    /// the whole texture, but rather a part of it.
+    /// By default, the texture rect covers the entire texture.
+    ///
+    /// \param rectangle Rectangle defining the region of the texture to display
+    ///
+    /// \see getTextureRect, setTexture
+    ///
+    ////////////////////////////////////////////////////////////
+    void setTextureRect(const IntRect& rectangle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the global color of the sprite
+    ///
+    /// This color is modulated (multiplied) with the sprite's
+    /// texture. It can be used to colorize the sprite, or change
+    /// its global opacity.
+    /// By default, the sprite's color is opaque white.
+    ///
+    /// \param color New color of the sprite
+    ///
+    /// \see getColor
+    ///
+    ////////////////////////////////////////////////////////////
+    void setColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the source texture of the sprite
+    ///
+    /// If the sprite has no source texture, a NULL pointer is returned.
+    /// The returned pointer is const, which means that you can't
+    /// modify the texture when you retrieve it with this function.
+    ///
+    /// \return Pointer to the sprite's texture
+    ///
+    /// \see setTexture
+    ///
+    ////////////////////////////////////////////////////////////
+    const Texture* getTexture() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the sub-rectangle of the texture displayed by the sprite
+    ///
+    /// \return Texture rectangle of the sprite
+    ///
+    /// \see setTextureRect
+    ///
+    ////////////////////////////////////////////////////////////
+    const IntRect& getTextureRect() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the global color of the sprite
+    ///
+    /// \return Global color of the sprite
+    ///
+    /// \see setColor
+    ///
+    ////////////////////////////////////////////////////////////
+    const Color& getColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the local bounding rectangle of the entity
+    ///
+    /// The returned rectangle is in local coordinates, which means
+    /// that it ignores the transformations (translation, rotation,
+    /// scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// entity in the entity's coordinate system.
+    ///
+    /// \return Local bounding rectangle of the entity
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getLocalBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the global bounding rectangle of the entity
+    ///
+    /// The returned rectangle is in global coordinates, which means
+    /// that it takes into account the transformations (translation,
+    /// rotation, scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// sprite in the global 2D world's coordinate system.
+    ///
+    /// \return Global bounding rectangle of the entity
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getGlobalBounds() const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw the sprite to a render target
+    ///
+    /// \param target Render target to draw to
+    /// \param states Current render states
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void draw(RenderTarget& target, RenderStates states) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the vertices' positions
+    ///
+    ////////////////////////////////////////////////////////////
+    void updatePositions();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the vertices' texture coordinates
+    ///
+    ////////////////////////////////////////////////////////////
+    void updateTexCoords();
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Vertex         m_vertices[4]; ///< Vertices defining the sprite's geometry
+    const Texture* m_texture;     ///< Texture of the sprite
+    IntRect        m_textureRect; ///< Rectangle defining the area of the source texture to display
+};
+
+} // namespace sf
+
+
+#endif // SFML_SPRITE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Sprite
+/// \ingroup graphics
+///
+/// sf::Sprite is a drawable class that allows to easily display
+/// a texture (or a part of it) on a render target.
+///
+/// It inherits all the functions from sf::Transformable:
+/// position, rotation, scale, origin. It also adds sprite-specific
+/// properties such as the texture to use, the part of it to display,
+/// and some convenience functions to change the overall color of the
+/// sprite, or to get its bounding rectangle.
+///
+/// sf::Sprite works in combination with the sf::Texture class, which
+/// loads and provides the pixel data of a given texture.
+///
+/// The separation of sf::Sprite and sf::Texture allows more flexibility
+/// and better performances: indeed a sf::Texture is a heavy resource,
+/// and any operation on it is slow (often too slow for real-time
+/// applications). On the other side, a sf::Sprite is a lightweight
+/// object which can use the pixel data of a sf::Texture and draw
+/// it with its own transformation/color/blending attributes.
+///
+/// It is important to note that the sf::Sprite instance doesn't
+/// copy the texture that it uses, it only keeps a reference to it.
+/// Thus, a sf::Texture must not be destroyed while it is
+/// used by a sf::Sprite (i.e. never write a function that
+/// uses a local sf::Texture instance for creating a sprite).
+///
+/// See also the note on coordinates and undistorted rendering in sf::Transformable.
+///
+/// Usage example:
+/// \code
+/// // Declare and load a texture
+/// sf::Texture texture;
+/// texture.loadFromFile("texture.png");
+///
+/// // Create a sprite
+/// sf::Sprite sprite;
+/// sprite.setTexture(texture);
+/// sprite.setTextureRect(sf::IntRect(10, 10, 50, 30));
+/// sprite.setColor(sf::Color(255, 255, 255, 200));
+/// sprite.setPosition(100, 25);
+///
+/// // Draw it
+/// window.draw(sprite);
+/// \endcode
+///
+/// \see sf::Texture, sf::Transformable
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Text.hpp
+++ b/libs/include/SFML/Graphics/Text.hpp
@@ -1,0 +1,513 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_TEXT_HPP
+#define SFML_TEXT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Graphics/Transformable.hpp>
+#include <SFML/Graphics/Font.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/Graphics/VertexArray.hpp>
+#include <SFML/System/String.hpp>
+#include <string>
+#include <vector>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Graphical text that can be drawn to a render target
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Text : public Drawable, public Transformable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enumeration of the string drawing styles
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Style
+    {
+        Regular       = 0,      ///< Regular characters, no style
+        Bold          = 1 << 0, ///< Bold characters
+        Italic        = 1 << 1, ///< Italic characters
+        Underlined    = 1 << 2, ///< Underlined characters
+        StrikeThrough = 1 << 3  ///< Strike through characters
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty text.
+    ///
+    ////////////////////////////////////////////////////////////
+    Text();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the text from a string, font and size
+    ///
+    /// Note that if the used font is a bitmap font, it is not
+    /// scalable, thus not all requested sizes will be available
+    /// to use. This needs to be taken into consideration when
+    /// setting the character size. If you need to display text
+    /// of a certain size, make sure the corresponding bitmap
+    /// font that supports that size is used.
+    ///
+    /// \param string         Text assigned to the string
+    /// \param font           Font used to draw the string
+    /// \param characterSize  Base size of characters, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    Text(const String& string, const Font& font, unsigned int characterSize = 30);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the text's string
+    ///
+    /// The \a string argument is a sf::String, which can
+    /// automatically be constructed from standard string types.
+    /// So, the following calls are all valid:
+    /// \code
+    /// text.setString("hello");
+    /// text.setString(L"hello");
+    /// text.setString(std::string("hello"));
+    /// text.setString(std::wstring(L"hello"));
+    /// \endcode
+    /// A text's string is empty by default.
+    ///
+    /// \param string New string
+    ///
+    /// \see getString
+    ///
+    ////////////////////////////////////////////////////////////
+    void setString(const String& string);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the text's font
+    ///
+    /// The \a font argument refers to a font that must
+    /// exist as long as the text uses it. Indeed, the text
+    /// doesn't store its own copy of the font, but rather keeps
+    /// a pointer to the one that you passed to this function.
+    /// If the font is destroyed and the text tries to
+    /// use it, the behavior is undefined.
+    ///
+    /// \param font New font
+    ///
+    /// \see getFont
+    ///
+    ////////////////////////////////////////////////////////////
+    void setFont(const Font& font);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the character size
+    ///
+    /// The default size is 30.
+    ///
+    /// Note that if the used font is a bitmap font, it is not
+    /// scalable, thus not all requested sizes will be available
+    /// to use. This needs to be taken into consideration when
+    /// setting the character size. If you need to display text
+    /// of a certain size, make sure the corresponding bitmap
+    /// font that supports that size is used.
+    ///
+    /// \param size New character size, in pixels
+    ///
+    /// \see getCharacterSize
+    ///
+    ////////////////////////////////////////////////////////////
+    void setCharacterSize(unsigned int size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the line spacing factor
+    ///
+    /// The default spacing between lines is defined by the font.
+    /// This method enables you to set a factor for the spacing
+    /// between lines. By default the line spacing factor is 1.
+    ///
+    /// \param spacingFactor New line spacing factor
+    ///
+    /// \see getLineSpacing
+    ///
+    ////////////////////////////////////////////////////////////
+    void setLineSpacing(float spacingFactor);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the letter spacing factor
+    ///
+    /// The default spacing between letters is defined by the font.
+    /// This factor doesn't directly apply to the existing
+    /// spacing between each character, it rather adds a fixed
+    /// space between them which is calculated from the font
+    /// metrics and the character size.
+    /// Note that factors below 1 (including negative numbers) bring
+    /// characters closer to each other.
+    /// By default the letter spacing factor is 1.
+    ///
+    /// \param spacingFactor New letter spacing factor
+    ///
+    /// \see getLetterSpacing
+    ///
+    ////////////////////////////////////////////////////////////
+    void setLetterSpacing(float spacingFactor);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the text's style
+    ///
+    /// You can pass a combination of one or more styles, for
+    /// example sf::Text::Bold | sf::Text::Italic.
+    /// The default style is sf::Text::Regular.
+    ///
+    /// \param style New style
+    ///
+    /// \see getStyle
+    ///
+    ////////////////////////////////////////////////////////////
+    void setStyle(Uint32 style);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the fill color of the text
+    ///
+    /// By default, the text's fill color is opaque white.
+    /// Setting the fill color to a transparent color with an outline
+    /// will cause the outline to be displayed in the fill area of the text.
+    ///
+    /// \param color New fill color of the text
+    ///
+    /// \see getFillColor
+    ///
+    /// \deprecated There is now fill and outline colors instead
+    /// of a single global color.
+    /// Use setFillColor() or setOutlineColor() instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED void setColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the fill color of the text
+    ///
+    /// By default, the text's fill color is opaque white.
+    /// Setting the fill color to a transparent color with an outline
+    /// will cause the outline to be displayed in the fill area of the text.
+    ///
+    /// \param color New fill color of the text
+    ///
+    /// \see getFillColor
+    ///
+    ////////////////////////////////////////////////////////////
+    void setFillColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the outline color of the text
+    ///
+    /// By default, the text's outline color is opaque black.
+    ///
+    /// \param color New outline color of the text
+    ///
+    /// \see getOutlineColor
+    ///
+    ////////////////////////////////////////////////////////////
+    void setOutlineColor(const Color& color);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the thickness of the text's outline
+    ///
+    /// By default, the outline thickness is 0.
+    ///
+    /// Be aware that using a negative value for the outline
+    /// thickness will cause distorted rendering.
+    ///
+    /// \param thickness New outline thickness, in pixels
+    ///
+    /// \see getOutlineThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    void setOutlineThickness(float thickness);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the text's string
+    ///
+    /// The returned string is a sf::String, which can automatically
+    /// be converted to standard string types. So, the following
+    /// lines of code are all valid:
+    /// \code
+    /// sf::String   s1 = text.getString();
+    /// std::string  s2 = text.getString();
+    /// std::wstring s3 = text.getString();
+    /// \endcode
+    ///
+    /// \return Text's string
+    ///
+    /// \see setString
+    ///
+    ////////////////////////////////////////////////////////////
+    const String& getString() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the text's font
+    ///
+    /// If the text has no font attached, a NULL pointer is returned.
+    /// The returned pointer is const, which means that you
+    /// cannot modify the font when you get it from this function.
+    ///
+    /// \return Pointer to the text's font
+    ///
+    /// \see setFont
+    ///
+    ////////////////////////////////////////////////////////////
+    const Font* getFont() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the character size
+    ///
+    /// \return Size of the characters, in pixels
+    ///
+    /// \see setCharacterSize
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getCharacterSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the size of the letter spacing factor
+    ///
+    /// \return Size of the letter spacing factor
+    ///
+    /// \see setLetterSpacing
+    ///
+    ////////////////////////////////////////////////////////////
+    float getLetterSpacing() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the size of the line spacing factor
+    ///
+    /// \return Size of the line spacing factor
+    ///
+    /// \see setLineSpacing
+    ///
+    ////////////////////////////////////////////////////////////
+    float getLineSpacing() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the text's style
+    ///
+    /// \return Text's style
+    ///
+    /// \see setStyle
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint32 getStyle() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the fill color of the text
+    ///
+    /// \return Fill color of the text
+    ///
+    /// \see setFillColor
+    ///
+    /// \deprecated There is now fill and outline colors instead
+    /// of a single global color.
+    /// Use getFillColor() or getOutlineColor() instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    SFML_DEPRECATED const Color& getColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the fill color of the text
+    ///
+    /// \return Fill color of the text
+    ///
+    /// \see setFillColor
+    ///
+    ////////////////////////////////////////////////////////////
+    const Color& getFillColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the outline color of the text
+    ///
+    /// \return Outline color of the text
+    ///
+    /// \see setOutlineColor
+    ///
+    ////////////////////////////////////////////////////////////
+    const Color& getOutlineColor() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the outline thickness of the text
+    ///
+    /// \return Outline thickness of the text, in pixels
+    ///
+    /// \see setOutlineThickness
+    ///
+    ////////////////////////////////////////////////////////////
+    float getOutlineThickness() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the position of the \a index-th character
+    ///
+    /// This function computes the visual position of a character
+    /// from its index in the string. The returned position is
+    /// in global coordinates (translation, rotation, scale and
+    /// origin are applied).
+    /// If \a index is out of range, the position of the end of
+    /// the string is returned.
+    ///
+    /// \param index Index of the character
+    ///
+    /// \return Position of the character
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2f findCharacterPos(std::size_t index) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the local bounding rectangle of the entity
+    ///
+    /// The returned rectangle is in local coordinates, which means
+    /// that it ignores the transformations (translation, rotation,
+    /// scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// entity in the entity's coordinate system.
+    ///
+    /// \return Local bounding rectangle of the entity
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getLocalBounds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the global bounding rectangle of the entity
+    ///
+    /// The returned rectangle is in global coordinates, which means
+    /// that it takes into account the transformations (translation,
+    /// rotation, scale, ...) that are applied to the entity.
+    /// In other words, this function returns the bounds of the
+    /// text in the global 2D world's coordinate system.
+    ///
+    /// \return Global bounding rectangle of the entity
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getGlobalBounds() const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw the text to a render target
+    ///
+    /// \param target Render target to draw to
+    /// \param states Current render states
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void draw(RenderTarget& target, RenderStates states) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Make sure the text's geometry is updated
+    ///
+    /// All the attributes related to rendering are cached, such
+    /// that the geometry is only updated when necessary.
+    ///
+    ////////////////////////////////////////////////////////////
+    void ensureGeometryUpdate() const;
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    String              m_string;              ///< String to display
+    const Font*         m_font;                ///< Font used to display the string
+    unsigned int        m_characterSize;       ///< Base size of characters, in pixels
+    float               m_letterSpacingFactor; ///< Spacing factor between letters
+    float               m_lineSpacingFactor;   ///< Spacing factor between lines
+    Uint32              m_style;               ///< Text style (see Style enum)
+    Color               m_fillColor;           ///< Text fill color
+    Color               m_outlineColor;        ///< Text outline color
+    float               m_outlineThickness;    ///< Thickness of the text's outline
+    mutable VertexArray m_vertices;            ///< Vertex array containing the fill geometry
+    mutable VertexArray m_outlineVertices;     ///< Vertex array containing the outline geometry
+    mutable FloatRect   m_bounds;              ///< Bounding rectangle of the text (in local coordinates)
+    mutable bool        m_geometryNeedUpdate;  ///< Does the geometry need to be recomputed?
+    mutable Uint64      m_fontTextureId;       ///< The font texture id
+};
+
+} // namespace sf
+
+
+#endif // SFML_TEXT_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Text
+/// \ingroup graphics
+///
+/// sf::Text is a drawable class that allows to easily display
+/// some text with custom style and color on a render target.
+///
+/// It inherits all the functions from sf::Transformable:
+/// position, rotation, scale, origin. It also adds text-specific
+/// properties such as the font to use, the character size,
+/// the font style (bold, italic, underlined and strike through), the
+/// text color, the outline thickness, the outline color, the character
+/// spacing, the line spacing and the text to display of course.
+/// It also provides convenience functions to calculate the
+/// graphical size of the text, or to get the global position
+/// of a given character.
+///
+/// sf::Text works in combination with the sf::Font class, which
+/// loads and provides the glyphs (visual characters) of a given font.
+///
+/// The separation of sf::Font and sf::Text allows more flexibility
+/// and better performances: indeed a sf::Font is a heavy resource,
+/// and any operation on it is slow (often too slow for real-time
+/// applications). On the other side, a sf::Text is a lightweight
+/// object which can combine the glyphs data and metrics of a sf::Font
+/// to display any text on a render target.
+///
+/// It is important to note that the sf::Text instance doesn't
+/// copy the font that it uses, it only keeps a reference to it.
+/// Thus, a sf::Font must not be destructed while it is
+/// used by a sf::Text (i.e. never write a function that
+/// uses a local sf::Font instance for creating a text).
+///
+/// See also the note on coordinates and undistorted rendering in sf::Transformable.
+///
+/// Usage example:
+/// \code
+/// // Declare and load a font
+/// sf::Font font;
+/// font.loadFromFile("arial.ttf");
+///
+/// // Create a text
+/// sf::Text text("hello", font);
+/// text.setCharacterSize(30);
+/// text.setStyle(sf::Text::Bold);
+/// text.setFillColor(sf::Color::Red);
+///
+/// // Draw it
+/// window.draw(text);
+/// \endcode
+///
+/// \see sf::Font, sf::Transformable
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Texture.hpp
+++ b/libs/include/SFML/Graphics/Texture.hpp
@@ -1,0 +1,733 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_TEXTURE_HPP
+#define SFML_TEXTURE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Image.hpp>
+#include <SFML/Window/GlResource.hpp>
+
+
+namespace sf
+{
+class InputStream;
+class RenderTarget;
+class RenderTexture;
+class Text;
+class Window;
+
+////////////////////////////////////////////////////////////
+/// \brief Image living on the graphics card that can be used for drawing
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Texture : GlResource
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Types of texture coordinates that can be used for rendering
+    ///
+    ////////////////////////////////////////////////////////////
+    enum CoordinateType
+    {
+        Normalized, ///< Texture coordinates in range [0 .. 1]
+        Pixels      ///< Texture coordinates in range [0 .. size]
+    };
+
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty texture.
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture(const Texture& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Texture();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the texture
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param width  Width of the texture
+    /// \param height Height of the texture
+    ///
+    /// \return True if creation was successful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool create(unsigned int width, unsigned int height);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the texture from a file on disk
+    ///
+    /// This function is a shortcut for the following code:
+    /// \code
+    /// sf::Image image;
+    /// image.loadFromFile(filename);
+    /// texture.loadFromImage(image, area);
+    /// \endcode
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param filename Path of the image file to load
+    /// \param area     Area of the image to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromMemory, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromFile(const std::string& filename, const IntRect& area = IntRect());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the texture from a file in memory
+    ///
+    /// This function is a shortcut for the following code:
+    /// \code
+    /// sf::Image image;
+    /// image.loadFromMemory(data, size);
+    /// texture.loadFromImage(image, area);
+    /// \endcode
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param data Pointer to the file data in memory
+    /// \param size Size of the data to load, in bytes
+    /// \param area Area of the image to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromStream, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromMemory(const void* data, std::size_t size, const IntRect& area = IntRect());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the texture from a custom stream
+    ///
+    /// This function is a shortcut for the following code:
+    /// \code
+    /// sf::Image image;
+    /// image.loadFromStream(stream);
+    /// texture.loadFromImage(image, area);
+    /// \endcode
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param stream Source stream to read from
+    /// \param area   Area of the image to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromMemory, loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromStream(InputStream& stream, const IntRect& area = IntRect());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Load the texture from an image
+    ///
+    /// The \a area argument can be used to load only a sub-rectangle
+    /// of the whole image. If you want the entire image then leave
+    /// the default value (which is an empty IntRect).
+    /// If the \a area rectangle crosses the bounds of the image, it
+    /// is adjusted to fit the image size.
+    ///
+    /// The maximum size for a texture depends on the graphics
+    /// driver and can be retrieved with the getMaximumSize function.
+    ///
+    /// If this function fails, the texture is left unchanged.
+    ///
+    /// \param image Image to load into the texture
+    /// \param area  Area of the image to load
+    ///
+    /// \return True if loading was successful
+    ///
+    /// \see loadFromFile, loadFromMemory
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromImage(const Image& image, const IntRect& area = IntRect());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the size of the texture
+    ///
+    /// \return Size in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2u getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy the texture pixels to an image
+    ///
+    /// This function performs a slow operation that downloads
+    /// the texture's pixels from the graphics card and copies
+    /// them to a new image, potentially applying transformations
+    /// to pixels if necessary (texture may be padded or flipped).
+    ///
+    /// \return Image containing the texture's pixels
+    ///
+    /// \see loadFromImage
+    ///
+    ////////////////////////////////////////////////////////////
+    Image copyToImage() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the whole texture from an array of pixels
+    ///
+    /// The \a pixel array is assumed to have the same size as
+    /// the \a area rectangle, and to contain 32-bits RGBA pixels.
+    ///
+    /// No additional check is performed on the size of the pixel
+    /// array, passing invalid arguments will lead to an undefined
+    /// behavior.
+    ///
+    /// This function does nothing if \a pixels is null or if the
+    /// texture was not previously created.
+    ///
+    /// \param pixels Array of pixels to copy to the texture
+    ///
+    ////////////////////////////////////////////////////////////
+    void update(const Uint8* pixels);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update a part of the texture from an array of pixels
+    ///
+    /// The size of the \a pixel array must match the \a width and
+    /// \a height arguments, and it must contain 32-bits RGBA pixels.
+    ///
+    /// No additional check is performed on the size of the pixel
+    /// array or the bounds of the area to update, passing invalid
+    /// arguments will lead to an undefined behavior.
+    ///
+    /// This function does nothing if \a pixels is null or if the
+    /// texture was not previously created.
+    ///
+    /// \param pixels Array of pixels to copy to the texture
+    /// \param width  Width of the pixel region contained in \a pixels
+    /// \param height Height of the pixel region contained in \a pixels
+    /// \param x      X offset in the texture where to copy the source pixels
+    /// \param y      Y offset in the texture where to copy the source pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    void update(const Uint8* pixels, unsigned int width, unsigned int height, unsigned int x, unsigned int y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update a part of this texture from another texture
+    ///
+    /// Although the source texture can be smaller than this texture,
+    /// this function is usually used for updating the whole texture.
+    /// The other overload, which has (x, y) additional arguments,
+    /// is more convenient for updating a sub-area of this texture.
+    ///
+    /// No additional check is performed on the size of the passed
+    /// texture, passing a texture bigger than this texture
+    /// will lead to an undefined behavior.
+    ///
+    /// This function does nothing if either texture was not
+    /// previously created.
+    ///
+    /// \param texture Source texture to copy to this texture
+    ///
+    ////////////////////////////////////////////////////////////
+    void update(const Texture& texture);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update a part of this texture from another texture
+    ///
+    /// No additional check is performed on the size of the texture,
+    /// passing an invalid combination of texture size and offset
+    /// will lead to an undefined behavior.
+    ///
+    /// This function does nothing if either texture was not
+    /// previously created.
+    ///
+    /// \param texture Source texture to copy to this texture
+    /// \param x       X offset in this texture where to copy the source texture
+    /// \param y       Y offset in this texture where to copy the source texture
+    ///
+    ////////////////////////////////////////////////////////////
+    void update(const Texture& texture, unsigned int x, unsigned int y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the texture from an image
+    ///
+    /// Although the source image can be smaller than the texture,
+    /// this function is usually used for updating the whole texture.
+    /// The other overload, which has (x, y) additional arguments,
+    /// is more convenient for updating a sub-area of the texture.
+    ///
+    /// No additional check is performed on the size of the image,
+    /// passing an image bigger than the texture will lead to an
+    /// undefined behavior.
+    ///
+    /// This function does nothing if the texture was not
+    /// previously created.
+    ///
+    /// \param image Image to copy to the texture
+    ///
+    ////////////////////////////////////////////////////////////
+    void update(const Image& image);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update a part of the texture from an image
+    ///
+    /// No additional check is performed on the size of the image,
+    /// passing an invalid combination of image size and offset
+    /// will lead to an undefined behavior.
+    ///
+    /// This function does nothing if the texture was not
+    /// previously created.
+    ///
+    /// \param image Image to copy to the texture
+    /// \param x     X offset in the texture where to copy the source image
+    /// \param y     Y offset in the texture where to copy the source image
+    ///
+    ////////////////////////////////////////////////////////////
+    void update(const Image& image, unsigned int x, unsigned int y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the texture from the contents of a window
+    ///
+    /// Although the source window can be smaller than the texture,
+    /// this function is usually used for updating the whole texture.
+    /// The other overload, which has (x, y) additional arguments,
+    /// is more convenient for updating a sub-area of the texture.
+    ///
+    /// No additional check is performed on the size of the window,
+    /// passing a window bigger than the texture will lead to an
+    /// undefined behavior.
+    ///
+    /// This function does nothing if either the texture or the window
+    /// was not previously created.
+    ///
+    /// \param window Window to copy to the texture
+    ///
+    ////////////////////////////////////////////////////////////
+    void update(const Window& window);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update a part of the texture from the contents of a window
+    ///
+    /// No additional check is performed on the size of the window,
+    /// passing an invalid combination of window size and offset
+    /// will lead to an undefined behavior.
+    ///
+    /// This function does nothing if either the texture or the window
+    /// was not previously created.
+    ///
+    /// \param window Window to copy to the texture
+    /// \param x      X offset in the texture where to copy the source window
+    /// \param y      Y offset in the texture where to copy the source window
+    ///
+    ////////////////////////////////////////////////////////////
+    void update(const Window& window, unsigned int x, unsigned int y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable the smooth filter
+    ///
+    /// When the filter is activated, the texture appears smoother
+    /// so that pixels are less noticeable. However if you want
+    /// the texture to look exactly the same as its source file,
+    /// you should leave it disabled.
+    /// The smooth filter is disabled by default.
+    ///
+    /// \param smooth True to enable smoothing, false to disable it
+    ///
+    /// \see isSmooth
+    ///
+    ////////////////////////////////////////////////////////////
+    void setSmooth(bool smooth);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the smooth filter is enabled or not
+    ///
+    /// \return True if smoothing is enabled, false if it is disabled
+    ///
+    /// \see setSmooth
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isSmooth() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable conversion from sRGB
+    ///
+    /// When providing texture data from an image file or memory, it can
+    /// either be stored in a linear color space or an sRGB color space.
+    /// Most digital images account for gamma correction already, so they
+    /// would need to be "uncorrected" back to linear color space before
+    /// being processed by the hardware. The hardware can automatically
+    /// convert it from the sRGB color space to a linear color space when
+    /// it gets sampled. When the rendered image gets output to the final
+    /// framebuffer, it gets converted back to sRGB.
+    ///
+    /// After enabling or disabling sRGB conversion, make sure to reload
+    /// the texture data in order for the setting to take effect.
+    ///
+    /// This option is only useful in conjunction with an sRGB capable
+    /// framebuffer. This can be requested during window creation.
+    ///
+    /// \param sRgb True to enable sRGB conversion, false to disable it
+    ///
+    /// \see isSrgb
+    ///
+    ////////////////////////////////////////////////////////////
+    void setSrgb(bool sRgb);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the texture source is converted from sRGB or not
+    ///
+    /// \return True if the texture source is converted from sRGB, false if not
+    ///
+    /// \see setSrgb
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isSrgb() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable repeating
+    ///
+    /// Repeating is involved when using texture coordinates
+    /// outside the texture rectangle [0, 0, width, height].
+    /// In this case, if repeat mode is enabled, the whole texture
+    /// will be repeated as many times as needed to reach the
+    /// coordinate (for example, if the X texture coordinate is
+    /// 3 * width, the texture will be repeated 3 times).
+    /// If repeat mode is disabled, the "extra space" will instead
+    /// be filled with border pixels.
+    /// Warning: on very old graphics cards, white pixels may appear
+    /// when the texture is repeated. With such cards, repeat mode
+    /// can be used reliably only if the texture has power-of-two
+    /// dimensions (such as 256x128).
+    /// Repeating is disabled by default.
+    ///
+    /// \param repeated True to repeat the texture, false to disable repeating
+    ///
+    /// \see isRepeated
+    ///
+    ////////////////////////////////////////////////////////////
+    void setRepeated(bool repeated);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the texture is repeated or not
+    ///
+    /// \return True if repeat mode is enabled, false if it is disabled
+    ///
+    /// \see setRepeated
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isRepeated() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Generate a mipmap using the current texture data
+    ///
+    /// Mipmaps are pre-computed chains of optimized textures. Each
+    /// level of texture in a mipmap is generated by halving each of
+    /// the previous level's dimensions. This is done until the final
+    /// level has the size of 1x1. The textures generated in this process may
+    /// make use of more advanced filters which might improve the visual quality
+    /// of textures when they are applied to objects much smaller than they are.
+    /// This is known as minification. Because fewer texels (texture elements)
+    /// have to be sampled from when heavily minified, usage of mipmaps
+    /// can also improve rendering performance in certain scenarios.
+    ///
+    /// Mipmap generation relies on the necessary OpenGL extension being
+    /// available. If it is unavailable or generation fails due to another
+    /// reason, this function will return false. Mipmap data is only valid from
+    /// the time it is generated until the next time the base level image is
+    /// modified, at which point this function will have to be called again to
+    /// regenerate it.
+    ///
+    /// \return True if mipmap generation was successful, false if unsuccessful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool generateMipmap();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    Texture& operator =(const Texture& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Swap the contents of this texture with those of another
+    ///
+    /// \param right Instance to swap with
+    ///
+    ////////////////////////////////////////////////////////////
+    void swap(Texture& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the underlying OpenGL handle of the texture.
+    ///
+    /// You shouldn't need to use this function, unless you have
+    /// very specific stuff to implement that SFML doesn't support,
+    /// or implement a temporary workaround until a bug is fixed.
+    ///
+    /// \return OpenGL handle of the texture or 0 if not yet created
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getNativeHandle() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Bind a texture for rendering
+    ///
+    /// This function is not part of the graphics API, it mustn't be
+    /// used when drawing SFML entities. It must be used only if you
+    /// mix sf::Texture with OpenGL code.
+    ///
+    /// \code
+    /// sf::Texture t1, t2;
+    /// ...
+    /// sf::Texture::bind(&t1);
+    /// // draw OpenGL stuff that use t1...
+    /// sf::Texture::bind(&t2);
+    /// // draw OpenGL stuff that use t2...
+    /// sf::Texture::bind(NULL);
+    /// // draw OpenGL stuff that use no texture...
+    /// \endcode
+    ///
+    /// The \a coordinateType argument controls how texture
+    /// coordinates will be interpreted. If Normalized (the default), they
+    /// must be in range [0 .. 1], which is the default way of handling
+    /// texture coordinates with OpenGL. If Pixels, they must be given
+    /// in pixels (range [0 .. size]). This mode is used internally by
+    /// the graphics classes of SFML, it makes the definition of texture
+    /// coordinates more intuitive for the high-level API, users don't need
+    /// to compute normalized values.
+    ///
+    /// \param texture Pointer to the texture to bind, can be null to use no texture
+    /// \param coordinateType Type of texture coordinates to use
+    ///
+    ////////////////////////////////////////////////////////////
+    static void bind(const Texture* texture, CoordinateType coordinateType = Normalized);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the maximum texture size allowed
+    ///
+    /// This maximum size is defined by the graphics driver.
+    /// You can expect a value of 512 pixels for low-end graphics
+    /// card, and up to 8192 pixels or more for newer hardware.
+    ///
+    /// \return Maximum size allowed for textures, in pixels
+    ///
+    ////////////////////////////////////////////////////////////
+    static unsigned int getMaximumSize();
+
+private:
+
+    friend class Text;
+    friend class RenderTexture;
+    friend class RenderTarget;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a valid image size according to hardware support
+    ///
+    /// This function checks whether the graphics driver supports
+    /// non power of two sizes or not, and adjusts the size
+    /// accordingly.
+    /// The returned size is greater than or equal to the original size.
+    ///
+    /// \param size size to convert
+    ///
+    /// \return Valid nearest size (greater than or equal to specified size)
+    ///
+    ////////////////////////////////////////////////////////////
+    static unsigned int getValidSize(unsigned int size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Invalidate the mipmap if one exists
+    ///
+    /// This also resets the texture's minifying function.
+    /// This function is mainly for internal use by RenderTexture.
+    ///
+    ////////////////////////////////////////////////////////////
+    void invalidateMipmap();
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Vector2u     m_size;          ///< Public texture size
+    Vector2u     m_actualSize;    ///< Actual texture size (can be greater than public size because of padding)
+    unsigned int m_texture;       ///< Internal texture identifier
+    bool         m_isSmooth;      ///< Status of the smooth filter
+    bool         m_sRgb;          ///< Should the texture source be converted from sRGB?
+    bool         m_isRepeated;    ///< Is the texture in repeat mode?
+    mutable bool m_pixelsFlipped; ///< To work around the inconsistency in Y orientation
+    bool         m_fboAttachment; ///< Is this texture owned by a framebuffer object?
+    bool         m_hasMipmap;     ///< Has the mipmap been generated?
+    Uint64       m_cacheId;       ///< Unique number that identifies the texture to the render target's cache
+};
+
+} // namespace sf
+
+
+#endif // SFML_TEXTURE_HPP
+
+////////////////////////////////////////////////////////////
+/// \class sf::Texture
+/// \ingroup graphics
+///
+/// sf::Texture stores pixels that can be drawn, with a sprite
+/// for example. A texture lives in the graphics card memory,
+/// therefore it is very fast to draw a texture to a render target,
+/// or copy a render target to a texture (the graphics card can
+/// access both directly).
+///
+/// Being stored in the graphics card memory has some drawbacks.
+/// A texture cannot be manipulated as freely as a sf::Image,
+/// you need to prepare the pixels first and then upload them
+/// to the texture in a single operation (see Texture::update).
+///
+/// sf::Texture makes it easy to convert from/to sf::Image, but
+/// keep in mind that these calls require transfers between
+/// the graphics card and the central memory, therefore they are
+/// slow operations.
+///
+/// A texture can be loaded from an image, but also directly
+/// from a file/memory/stream. The necessary shortcuts are defined
+/// so that you don't need an image first for the most common cases.
+/// However, if you want to perform some modifications on the pixels
+/// before creating the final texture, you can load your file to a
+/// sf::Image, do whatever you need with the pixels, and then call
+/// Texture::loadFromImage.
+///
+/// Since they live in the graphics card memory, the pixels of a texture
+/// cannot be accessed without a slow copy first. And they cannot be
+/// accessed individually. Therefore, if you need to read the texture's
+/// pixels (like for pixel-perfect collisions), it is recommended to
+/// store the collision information separately, for example in an array
+/// of booleans.
+///
+/// Like sf::Image, sf::Texture can handle a unique internal
+/// representation of pixels, which is RGBA 32 bits. This means
+/// that a pixel must be composed of 8 bits red, green, blue and
+/// alpha channels -- just like a sf::Color.
+///
+/// Usage example:
+/// \code
+/// // This example shows the most common use of sf::Texture:
+/// // drawing a sprite
+///
+/// // Load a texture from a file
+/// sf::Texture texture;
+/// if (!texture.loadFromFile("texture.png"))
+///     return -1;
+///
+/// // Assign it to a sprite
+/// sf::Sprite sprite;
+/// sprite.setTexture(texture);
+///
+/// // Draw the textured sprite
+/// window.draw(sprite);
+/// \endcode
+///
+/// \code
+/// // This example shows another common use of sf::Texture:
+/// // streaming real-time data, like video frames
+///
+/// // Create an empty texture
+/// sf::Texture texture;
+/// if (!texture.create(640, 480))
+///     return -1;
+///
+/// // Create a sprite that will display the texture
+/// sf::Sprite sprite(texture);
+///
+/// while (...) // the main loop
+/// {
+///     ...
+///
+///     // update the texture
+///     sf::Uint8* pixels = ...; // get a fresh chunk of pixels (the next frame of a movie, for example)
+///     texture.update(pixels);
+///
+///     // draw it
+///     window.draw(sprite);
+///
+///     ...
+/// }
+///
+/// \endcode
+///
+/// Like sf::Shader that can be used as a raw OpenGL shader,
+/// sf::Texture can also be used directly as a raw texture for
+/// custom OpenGL geometry.
+/// \code
+/// sf::Texture::bind(&texture);
+/// ... render OpenGL geometry ...
+/// sf::Texture::bind(NULL);
+/// \endcode
+///
+/// \see sf::Sprite, sf::Image, sf::RenderTexture
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Transform.hpp
+++ b/libs/include/SFML/Graphics/Transform.hpp
@@ -1,0 +1,479 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_TRANSFORM_HPP
+#define SFML_TRANSFORM_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/System/Vector2.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Define a 3x3 transform matrix
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Transform
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an identity transform (a transform that does nothing).
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a transform from a 3x3 matrix
+    ///
+    /// \param a00 Element (0, 0) of the matrix
+    /// \param a01 Element (0, 1) of the matrix
+    /// \param a02 Element (0, 2) of the matrix
+    /// \param a10 Element (1, 0) of the matrix
+    /// \param a11 Element (1, 1) of the matrix
+    /// \param a12 Element (1, 2) of the matrix
+    /// \param a20 Element (2, 0) of the matrix
+    /// \param a21 Element (2, 1) of the matrix
+    /// \param a22 Element (2, 2) of the matrix
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform(float a00, float a01, float a02,
+              float a10, float a11, float a12,
+              float a20, float a21, float a22);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the transform as a 4x4 matrix
+    ///
+    /// This function returns a pointer to an array of 16 floats
+    /// containing the transform elements as a 4x4 matrix, which
+    /// is directly compatible with OpenGL functions.
+    ///
+    /// \code
+    /// sf::Transform transform = ...;
+    /// glLoadMatrixf(transform.getMatrix());
+    /// \endcode
+    ///
+    /// \return Pointer to a 4x4 matrix
+    ///
+    ////////////////////////////////////////////////////////////
+    const float* getMatrix() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the inverse of the transform
+    ///
+    /// If the inverse cannot be computed, an identity transform
+    /// is returned.
+    ///
+    /// \return A new transform which is the inverse of self
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform getInverse() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Transform a 2D point
+    ///
+    /// \param x X coordinate of the point to transform
+    /// \param y Y coordinate of the point to transform
+    ///
+    /// \return Transformed point
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2f transformPoint(float x, float y) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Transform a 2D point
+    ///
+    /// \param point Point to transform
+    ///
+    /// \return Transformed point
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2f transformPoint(const Vector2f& point) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Transform a rectangle
+    ///
+    /// Since SFML doesn't provide support for oriented rectangles,
+    /// the result of this function is always an axis-aligned
+    /// rectangle. Which means that if the transform contains a
+    /// rotation, the bounding rectangle of the transformed rectangle
+    /// is returned.
+    ///
+    /// \param rectangle Rectangle to transform
+    ///
+    /// \return Transformed rectangle
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect transformRect(const FloatRect& rectangle) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with another one
+    ///
+    /// The result is a transform that is equivalent to applying
+    /// *this followed by \a transform. Mathematically, it is
+    /// equivalent to a matrix multiplication.
+    ///
+    /// \param transform Transform to combine with this transform
+    ///
+    /// \return Reference to *this
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& combine(const Transform& transform);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a translation
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.translate(100, 200).rotate(45);
+    /// \endcode
+    ///
+    /// \param x Offset to apply on X axis
+    /// \param y Offset to apply on Y axis
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see rotate, scale
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& translate(float x, float y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a translation
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.translate(sf::Vector2f(100, 200)).rotate(45);
+    /// \endcode
+    ///
+    /// \param offset Translation offset to apply
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see rotate, scale
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& translate(const Vector2f& offset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a rotation
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.rotate(90).translate(50, 20);
+    /// \endcode
+    ///
+    /// \param angle Rotation angle, in degrees
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see translate, scale
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& rotate(float angle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a rotation
+    ///
+    /// The center of rotation is provided for convenience as a second
+    /// argument, so that you can build rotations around arbitrary points
+    /// more easily (and efficiently) than the usual
+    /// translate(-center).rotate(angle).translate(center).
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.rotate(90, 8, 3).translate(50, 20);
+    /// \endcode
+    ///
+    /// \param angle Rotation angle, in degrees
+    /// \param centerX X coordinate of the center of rotation
+    /// \param centerY Y coordinate of the center of rotation
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see translate, scale
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& rotate(float angle, float centerX, float centerY);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a rotation
+    ///
+    /// The center of rotation is provided for convenience as a second
+    /// argument, so that you can build rotations around arbitrary points
+    /// more easily (and efficiently) than the usual
+    /// translate(-center).rotate(angle).translate(center).
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.rotate(90, sf::Vector2f(8, 3)).translate(sf::Vector2f(50, 20));
+    /// \endcode
+    ///
+    /// \param angle Rotation angle, in degrees
+    /// \param center Center of rotation
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see translate, scale
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& rotate(float angle, const Vector2f& center);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a scaling
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.scale(2, 1).rotate(45);
+    /// \endcode
+    ///
+    /// \param scaleX Scaling factor on the X axis
+    /// \param scaleY Scaling factor on the Y axis
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see translate, rotate
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& scale(float scaleX, float scaleY);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a scaling
+    ///
+    /// The center of scaling is provided for convenience as a second
+    /// argument, so that you can build scaling around arbitrary points
+    /// more easily (and efficiently) than the usual
+    /// translate(-center).scale(factors).translate(center).
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.scale(2, 1, 8, 3).rotate(45);
+    /// \endcode
+    ///
+    /// \param scaleX Scaling factor on X axis
+    /// \param scaleY Scaling factor on Y axis
+    /// \param centerX X coordinate of the center of scaling
+    /// \param centerY Y coordinate of the center of scaling
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see translate, rotate
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& scale(float scaleX, float scaleY, float centerX, float centerY);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a scaling
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.scale(sf::Vector2f(2, 1)).rotate(45);
+    /// \endcode
+    ///
+    /// \param factors Scaling factors
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see translate, rotate
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& scale(const Vector2f& factors);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Combine the current transform with a scaling
+    ///
+    /// The center of scaling is provided for convenience as a second
+    /// argument, so that you can build scaling around arbitrary points
+    /// more easily (and efficiently) than the usual
+    /// translate(-center).scale(factors).translate(center).
+    ///
+    /// This function returns a reference to *this, so that calls
+    /// can be chained.
+    /// \code
+    /// sf::Transform transform;
+    /// transform.scale(sf::Vector2f(2, 1), sf::Vector2f(8, 3)).rotate(45);
+    /// \endcode
+    ///
+    /// \param factors Scaling factors
+    /// \param center Center of scaling
+    ///
+    /// \return Reference to *this
+    ///
+    /// \see translate, rotate
+    ///
+    ////////////////////////////////////////////////////////////
+    Transform& scale(const Vector2f& factors, const Vector2f& center);
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static const Transform Identity; ///< The identity transform (does nothing)
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    float m_matrix[16]; ///< 4x4 matrix defining the transformation
+};
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Transform
+/// \brief Overload of binary operator * to combine two transforms
+///
+/// This call is equivalent to calling Transform(left).combine(right).
+///
+/// \param left Left operand (the first transform)
+/// \param right Right operand (the second transform)
+///
+/// \return New combined transform
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Transform operator *(const Transform& left, const Transform& right);
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Transform
+/// \brief Overload of binary operator *= to combine two transforms
+///
+/// This call is equivalent to calling left.combine(right).
+///
+/// \param left Left operand (the first transform)
+/// \param right Right operand (the second transform)
+///
+/// \return The combined transform
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Transform& operator *=(Transform& left, const Transform& right);
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Transform
+/// \brief Overload of binary operator * to transform a point
+///
+/// This call is equivalent to calling left.transformPoint(right).
+///
+/// \param left Left operand (the transform)
+/// \param right Right operand (the point to transform)
+///
+/// \return New transformed point
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API Vector2f operator *(const Transform& left, const Vector2f& right);
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Transform
+/// \brief Overload of binary operator == to compare two transforms
+///
+/// Performs an element-wise comparison of the elements of the
+/// left transform with the elements of the right transform.
+///
+/// \param left Left operand (the first transform)
+/// \param right Right operand (the second transform)
+///
+/// \return true if the transforms are equal, false otherwise
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API bool operator ==(const Transform& left, const Transform& right);
+
+////////////////////////////////////////////////////////////
+/// \relates sf::Transform
+/// \brief Overload of binary operator != to compare two transforms
+///
+/// This call is equivalent to !(left == right).
+///
+/// \param left Left operand (the first transform)
+/// \param right Right operand (the second transform)
+///
+/// \return true if the transforms are not equal, false otherwise
+///
+////////////////////////////////////////////////////////////
+SFML_GRAPHICS_API bool operator !=(const Transform& left, const Transform& right);
+
+} // namespace sf
+
+
+#endif // SFML_TRANSFORM_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Transform
+/// \ingroup graphics
+///
+/// A sf::Transform specifies how to translate, rotate, scale,
+/// shear, project, whatever things. In mathematical terms, it defines
+/// how to transform a coordinate system into another.
+///
+/// For example, if you apply a rotation transform to a sprite, the
+/// result will be a rotated sprite. And anything that is transformed
+/// by this rotation transform will be rotated the same way, according
+/// to its initial position.
+///
+/// Transforms are typically used for drawing. But they can also be
+/// used for any computation that requires to transform points between
+/// the local and global coordinate systems of an entity (like collision
+/// detection).
+///
+/// Example:
+/// \code
+/// // define a translation transform
+/// sf::Transform translation;
+/// translation.translate(20, 50);
+///
+/// // define a rotation transform
+/// sf::Transform rotation;
+/// rotation.rotate(45);
+///
+/// // combine them
+/// sf::Transform transform = translation * rotation;
+///
+/// // use the result to transform stuff...
+/// sf::Vector2f point = transform.transformPoint(10, 20);
+/// sf::FloatRect rect = transform.transformRect(sf::FloatRect(0, 0, 10, 100));
+/// \endcode
+///
+/// \see sf::Transformable, sf::RenderStates
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Transformable.hpp
+++ b/libs/include/SFML/Graphics/Transformable.hpp
@@ -1,0 +1,429 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_TRANSFORMABLE_HPP
+#define SFML_TRANSFORMABLE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Transform.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Decomposed transform defined by a position, a rotation and a scale
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Transformable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Transformable();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Virtual destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~Transformable();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief set the position of the object
+    ///
+    /// This function completely overwrites the previous position.
+    /// See the move function to apply an offset based on the previous position instead.
+    /// The default position of a transformable object is (0, 0).
+    ///
+    /// \param x X coordinate of the new position
+    /// \param y Y coordinate of the new position
+    ///
+    /// \see move, getPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPosition(float x, float y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief set the position of the object
+    ///
+    /// This function completely overwrites the previous position.
+    /// See the move function to apply an offset based on the previous position instead.
+    /// The default position of a transformable object is (0, 0).
+    ///
+    /// \param position New position
+    ///
+    /// \see move, getPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPosition(const Vector2f& position);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief set the orientation of the object
+    ///
+    /// This function completely overwrites the previous rotation.
+    /// See the rotate function to add an angle based on the previous rotation instead.
+    /// The default rotation of a transformable object is 0.
+    ///
+    /// \param angle New rotation, in degrees
+    ///
+    /// \see rotate, getRotation
+    ///
+    ////////////////////////////////////////////////////////////
+    void setRotation(float angle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief set the scale factors of the object
+    ///
+    /// This function completely overwrites the previous scale.
+    /// See the scale function to add a factor based on the previous scale instead.
+    /// The default scale of a transformable object is (1, 1).
+    ///
+    /// \param factorX New horizontal scale factor
+    /// \param factorY New vertical scale factor
+    ///
+    /// \see scale, getScale
+    ///
+    ////////////////////////////////////////////////////////////
+    void setScale(float factorX, float factorY);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief set the scale factors of the object
+    ///
+    /// This function completely overwrites the previous scale.
+    /// See the scale function to add a factor based on the previous scale instead.
+    /// The default scale of a transformable object is (1, 1).
+    ///
+    /// \param factors New scale factors
+    ///
+    /// \see scale, getScale
+    ///
+    ////////////////////////////////////////////////////////////
+    void setScale(const Vector2f& factors);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief set the local origin of the object
+    ///
+    /// The origin of an object defines the center point for
+    /// all transformations (position, scale, rotation).
+    /// The coordinates of this point must be relative to the
+    /// top-left corner of the object, and ignore all
+    /// transformations (position, scale, rotation).
+    /// The default origin of a transformable object is (0, 0).
+    ///
+    /// \param x X coordinate of the new origin
+    /// \param y Y coordinate of the new origin
+    ///
+    /// \see getOrigin
+    ///
+    ////////////////////////////////////////////////////////////
+    void setOrigin(float x, float y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief set the local origin of the object
+    ///
+    /// The origin of an object defines the center point for
+    /// all transformations (position, scale, rotation).
+    /// The coordinates of this point must be relative to the
+    /// top-left corner of the object, and ignore all
+    /// transformations (position, scale, rotation).
+    /// The default origin of a transformable object is (0, 0).
+    ///
+    /// \param origin New origin
+    ///
+    /// \see getOrigin
+    ///
+    ////////////////////////////////////////////////////////////
+    void setOrigin(const Vector2f& origin);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief get the position of the object
+    ///
+    /// \return Current position
+    ///
+    /// \see setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    const Vector2f& getPosition() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief get the orientation of the object
+    ///
+    /// The rotation is always in the range [0, 360].
+    ///
+    /// \return Current rotation, in degrees
+    ///
+    /// \see setRotation
+    ///
+    ////////////////////////////////////////////////////////////
+    float getRotation() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief get the current scale of the object
+    ///
+    /// \return Current scale factors
+    ///
+    /// \see setScale
+    ///
+    ////////////////////////////////////////////////////////////
+    const Vector2f& getScale() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief get the local origin of the object
+    ///
+    /// \return Current origin
+    ///
+    /// \see setOrigin
+    ///
+    ////////////////////////////////////////////////////////////
+    const Vector2f& getOrigin() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Move the object by a given offset
+    ///
+    /// This function adds to the current position of the object,
+    /// unlike setPosition which overwrites it.
+    /// Thus, it is equivalent to the following code:
+    /// \code
+    /// sf::Vector2f pos = object.getPosition();
+    /// object.setPosition(pos.x + offsetX, pos.y + offsetY);
+    /// \endcode
+    ///
+    /// \param offsetX X offset
+    /// \param offsetY Y offset
+    ///
+    /// \see setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    void move(float offsetX, float offsetY);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Move the object by a given offset
+    ///
+    /// This function adds to the current position of the object,
+    /// unlike setPosition which overwrites it.
+    /// Thus, it is equivalent to the following code:
+    /// \code
+    /// object.setPosition(object.getPosition() + offset);
+    /// \endcode
+    ///
+    /// \param offset Offset
+    ///
+    /// \see setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    void move(const Vector2f& offset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Rotate the object
+    ///
+    /// This function adds to the current rotation of the object,
+    /// unlike setRotation which overwrites it.
+    /// Thus, it is equivalent to the following code:
+    /// \code
+    /// object.setRotation(object.getRotation() + angle);
+    /// \endcode
+    ///
+    /// \param angle Angle of rotation, in degrees
+    ///
+    ////////////////////////////////////////////////////////////
+    void rotate(float angle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Scale the object
+    ///
+    /// This function multiplies the current scale of the object,
+    /// unlike setScale which overwrites it.
+    /// Thus, it is equivalent to the following code:
+    /// \code
+    /// sf::Vector2f scale = object.getScale();
+    /// object.setScale(scale.x * factorX, scale.y * factorY);
+    /// \endcode
+    ///
+    /// \param factorX Horizontal scale factor
+    /// \param factorY Vertical scale factor
+    ///
+    /// \see setScale
+    ///
+    ////////////////////////////////////////////////////////////
+    void scale(float factorX, float factorY);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Scale the object
+    ///
+    /// This function multiplies the current scale of the object,
+    /// unlike setScale which overwrites it.
+    /// Thus, it is equivalent to the following code:
+    /// \code
+    /// sf::Vector2f scale = object.getScale();
+    /// object.setScale(scale.x * factor.x, scale.y * factor.y);
+    /// \endcode
+    ///
+    /// \param factor Scale factors
+    ///
+    /// \see setScale
+    ///
+    ////////////////////////////////////////////////////////////
+    void scale(const Vector2f& factor);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief get the combined transform of the object
+    ///
+    /// \return Transform combining the position/rotation/scale/origin of the object
+    ///
+    /// \see getInverseTransform
+    ///
+    ////////////////////////////////////////////////////////////
+    const Transform& getTransform() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief get the inverse of the combined transform of the object
+    ///
+    /// \return Inverse of the combined transformations applied to the object
+    ///
+    /// \see getTransform
+    ///
+    ////////////////////////////////////////////////////////////
+    const Transform& getInverseTransform() const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Vector2f          m_origin;                     ///< Origin of translation/rotation/scaling of the object
+    Vector2f          m_position;                   ///< Position of the object in the 2D world
+    float             m_rotation;                   ///< Orientation of the object, in degrees
+    Vector2f          m_scale;                      ///< Scale of the object
+    mutable Transform m_transform;                  ///< Combined transformation of the object
+    mutable bool      m_transformNeedUpdate;        ///< Does the transform need to be recomputed?
+    mutable Transform m_inverseTransform;           ///< Combined transformation of the object
+    mutable bool      m_inverseTransformNeedUpdate; ///< Does the transform need to be recomputed?
+};
+
+} // namespace sf
+
+
+#endif // SFML_TRANSFORMABLE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Transformable
+/// \ingroup graphics
+///
+/// This class is provided for convenience, on top of sf::Transform.
+///
+/// sf::Transform, as a low-level class, offers a great level of
+/// flexibility but it is not always convenient to manage. Indeed,
+/// one can easily combine any kind of operation, such as a translation
+/// followed by a rotation followed by a scaling, but once the result
+/// transform is built, there's no way to go backward and, let's say,
+/// change only the rotation without modifying the translation and scaling.
+/// The entire transform must be recomputed, which means that you
+/// need to retrieve the initial translation and scale factors as
+/// well, and combine them the same way you did before updating the
+/// rotation. This is a tedious operation, and it requires to store
+/// all the individual components of the final transform.
+///
+/// That's exactly what sf::Transformable was written for: it hides
+/// these variables and the composed transform behind an easy to use
+/// interface. You can set or get any of the individual components
+/// without worrying about the others. It also provides the composed
+/// transform (as a sf::Transform), and keeps it up-to-date.
+///
+/// In addition to the position, rotation and scale, sf::Transformable
+/// provides an "origin" component, which represents the local origin
+/// of the three other components. Let's take an example with a 10x10
+/// pixels sprite. By default, the sprite is positioned/rotated/scaled
+/// relatively to its top-left corner, because it is the local point
+/// (0, 0). But if we change the origin to be (5, 5), the sprite will
+/// be positioned/rotated/scaled around its center instead. And if
+/// we set the origin to (10, 10), it will be transformed around its
+/// bottom-right corner.
+///
+/// To keep the sf::Transformable class simple, there's only one
+/// origin for all the components. You cannot position the sprite
+/// relatively to its top-left corner while rotating it around its
+/// center, for example. To do such things, use sf::Transform directly.
+///
+/// sf::Transformable can be used as a base class. It is often
+/// combined with sf::Drawable -- that's what SFML's sprites,
+/// texts and shapes do.
+/// \code
+/// class MyEntity : public sf::Transformable, public sf::Drawable
+/// {
+///     virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const
+///     {
+///         states.transform *= getTransform();
+///         target.draw(..., states);
+///     }
+/// };
+///
+/// MyEntity entity;
+/// entity.setPosition(10, 20);
+/// entity.setRotation(45);
+/// window.draw(entity);
+/// \endcode
+///
+/// It can also be used as a member, if you don't want to use
+/// its API directly (because you don't need all its functions,
+/// or you have different naming conventions for example).
+/// \code
+/// class MyEntity
+/// {
+/// public:
+///     void SetPosition(const MyVector& v)
+///     {
+///         myTransform.setPosition(v.x(), v.y());
+///     }
+///
+///     void Draw(sf::RenderTarget& target) const
+///     {
+///         target.draw(..., myTransform.getTransform());
+///     }
+///
+/// private:
+///     sf::Transformable myTransform;
+/// };
+/// \endcode
+///
+/// A note on coordinates and undistorted rendering: \n
+/// By default, SFML (or more exactly, OpenGL) may interpolate drawable objects
+/// such as sprites or texts when rendering. While this allows transitions
+/// like slow movements or rotations to appear smoothly, it can lead to
+/// unwanted results in some cases, for example blurred or distorted objects.
+/// In order to render a sf::Drawable object pixel-perfectly, make sure
+/// the involved coordinates allow a 1:1 mapping of pixels in the window
+/// to texels (pixels in the texture). More specifically, this means:
+/// * The object's position, origin and scale have no fractional part
+/// * The object's and the view's rotation are a multiple of 90 degrees
+/// * The view's center and size have no fractional part
+///
+/// \see sf::Transform
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/Vertex.hpp
+++ b/libs/include/SFML/Graphics/Vertex.hpp
@@ -1,0 +1,148 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_VERTEX_HPP
+#define SFML_VERTEX_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Color.hpp>
+#include <SFML/System/Vector2.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Define a point with color and texture coordinates
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API Vertex
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Vertex();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vertex from its position
+    ///
+    /// The vertex color is white and texture coordinates are (0, 0).
+    ///
+    /// \param thePosition Vertex position
+    ///
+    ////////////////////////////////////////////////////////////
+    Vertex(const Vector2f& thePosition);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vertex from its position and color
+    ///
+    /// The texture coordinates are (0, 0).
+    ///
+    /// \param thePosition Vertex position
+    /// \param theColor    Vertex color
+    ///
+    ////////////////////////////////////////////////////////////
+    Vertex(const Vector2f& thePosition, const Color& theColor);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vertex from its position and texture coordinates
+    ///
+    /// The vertex color is white.
+    ///
+    /// \param thePosition  Vertex position
+    /// \param theTexCoords Vertex texture coordinates
+    ///
+    ////////////////////////////////////////////////////////////
+    Vertex(const Vector2f& thePosition, const Vector2f& theTexCoords);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vertex from its position, color and texture coordinates
+    ///
+    /// \param thePosition  Vertex position
+    /// \param theColor     Vertex color
+    /// \param theTexCoords Vertex texture coordinates
+    ///
+    ////////////////////////////////////////////////////////////
+    Vertex(const Vector2f& thePosition, const Color& theColor, const Vector2f& theTexCoords);
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Vector2f  position;  ///< 2D position of the vertex
+    Color     color;     ///< Color of the vertex
+    Vector2f  texCoords; ///< Coordinates of the texture's pixel to map to the vertex
+};
+
+} // namespace sf
+
+
+#endif // SFML_VERTEX_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Vertex
+/// \ingroup graphics
+///
+/// A vertex is an improved point. It has a position and other
+/// extra attributes that will be used for drawing: in SFML,
+/// vertices also have a color and a pair of texture coordinates.
+///
+/// The vertex is the building block of drawing. Everything which
+/// is visible on screen is made of vertices. They are grouped
+/// as 2D primitives (triangles, quads, ...), and these primitives
+/// are grouped to create even more complex 2D entities such as
+/// sprites, texts, etc.
+///
+/// If you use the graphical entities of SFML (sprite, text, shape)
+/// you won't have to deal with vertices directly. But if you want
+/// to define your own 2D entities, such as tiled maps or particle
+/// systems, using vertices will allow you to get maximum performances.
+///
+/// Example:
+/// \code
+/// // define a 100x100 square, red, with a 10x10 texture mapped on it
+/// sf::Vertex vertices[] =
+/// {
+///     sf::Vertex(sf::Vector2f(  0,   0), sf::Color::Red, sf::Vector2f( 0,  0)),
+///     sf::Vertex(sf::Vector2f(  0, 100), sf::Color::Red, sf::Vector2f( 0, 10)),
+///     sf::Vertex(sf::Vector2f(100, 100), sf::Color::Red, sf::Vector2f(10, 10)),
+///     sf::Vertex(sf::Vector2f(100,   0), sf::Color::Red, sf::Vector2f(10,  0))
+/// };
+///
+/// // draw it
+/// window.draw(vertices, 4, sf::Quads);
+/// \endcode
+///
+/// Note: although texture coordinates are supposed to be an integer
+/// amount of pixels, their type is float because of some buggy graphics
+/// drivers that are not able to process integer coordinates correctly.
+///
+/// \see sf::VertexArray
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/VertexArray.hpp
+++ b/libs/include/SFML/Graphics/VertexArray.hpp
@@ -1,0 +1,223 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_VERTEXARRAY_HPP
+#define SFML_VERTEXARRAY_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Vertex.hpp>
+#include <SFML/Graphics/PrimitiveType.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/Graphics/Drawable.hpp>
+#include <vector>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Define a set of one or more 2D primitives
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API VertexArray : public Drawable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty vertex array.
+    ///
+    ////////////////////////////////////////////////////////////
+    VertexArray();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vertex array with a type and an initial number of vertices
+    ///
+    /// \param type        Type of primitives
+    /// \param vertexCount Initial number of vertices in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit VertexArray(PrimitiveType type, std::size_t vertexCount = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the vertex count
+    ///
+    /// \return Number of vertices in the array
+    ///
+    ////////////////////////////////////////////////////////////
+    std::size_t getVertexCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a read-write access to a vertex by its index
+    ///
+    /// This function doesn't check \a index, it must be in range
+    /// [0, getVertexCount() - 1]. The behavior is undefined
+    /// otherwise.
+    ///
+    /// \param index Index of the vertex to get
+    ///
+    /// \return Reference to the index-th vertex
+    ///
+    /// \see getVertexCount
+    ///
+    ////////////////////////////////////////////////////////////
+    Vertex& operator [](std::size_t index);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a read-only access to a vertex by its index
+    ///
+    /// This function doesn't check \a index, it must be in range
+    /// [0, getVertexCount() - 1]. The behavior is undefined
+    /// otherwise.
+    ///
+    /// \param index Index of the vertex to get
+    ///
+    /// \return Const reference to the index-th vertex
+    ///
+    /// \see getVertexCount
+    ///
+    ////////////////////////////////////////////////////////////
+    const Vertex& operator [](std::size_t index) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clear the vertex array
+    ///
+    /// This function removes all the vertices from the array.
+    /// It doesn't deallocate the corresponding memory, so that
+    /// adding new vertices after clearing doesn't involve
+    /// reallocating all the memory.
+    ///
+    ////////////////////////////////////////////////////////////
+    void clear();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Resize the vertex array
+    ///
+    /// If \a vertexCount is greater than the current size, the previous
+    /// vertices are kept and new (default-constructed) vertices are
+    /// added.
+    /// If \a vertexCount is less than the current size, existing vertices
+    /// are removed from the array.
+    ///
+    /// \param vertexCount New size of the array (number of vertices)
+    ///
+    ////////////////////////////////////////////////////////////
+    void resize(std::size_t vertexCount);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Add a vertex to the array
+    ///
+    /// \param vertex Vertex to add
+    ///
+    ////////////////////////////////////////////////////////////
+    void append(const Vertex& vertex);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the type of primitives to draw
+    ///
+    /// This function defines how the vertices must be interpreted
+    /// when it's time to draw them:
+    /// \li As points
+    /// \li As lines
+    /// \li As triangles
+    /// \li As quads
+    /// The default primitive type is sf::Points.
+    ///
+    /// \param type Type of primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPrimitiveType(PrimitiveType type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the type of primitives drawn by the vertex array
+    ///
+    /// \return Primitive type
+    ///
+    ////////////////////////////////////////////////////////////
+    PrimitiveType getPrimitiveType() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Compute the bounding rectangle of the vertex array
+    ///
+    /// This function returns the minimal axis-aligned rectangle
+    /// that contains all the vertices of the array.
+    ///
+    /// \return Bounding rectangle of the vertex array
+    ///
+    ////////////////////////////////////////////////////////////
+    FloatRect getBounds() const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw the vertex array to a render target
+    ///
+    /// \param target Render target to draw to
+    /// \param states Current render states
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void draw(RenderTarget& target, RenderStates states) const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::vector<Vertex> m_vertices;      ///< Vertices contained in the array
+    PrimitiveType       m_primitiveType; ///< Type of primitives to draw
+};
+
+} // namespace sf
+
+
+#endif // SFML_VERTEXARRAY_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::VertexArray
+/// \ingroup graphics
+///
+/// sf::VertexArray is a very simple wrapper around a dynamic
+/// array of vertices and a primitives type.
+///
+/// It inherits sf::Drawable, but unlike other drawables it
+/// is not transformable.
+///
+/// Example:
+/// \code
+/// sf::VertexArray lines(sf::LineStrip, 4);
+/// lines[0].position = sf::Vector2f(10, 0);
+/// lines[1].position = sf::Vector2f(20, 0);
+/// lines[2].position = sf::Vector2f(30, 5);
+/// lines[3].position = sf::Vector2f(40, 2);
+///
+/// window.draw(lines);
+/// \endcode
+///
+/// \see sf::Vertex
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/VertexBuffer.hpp
+++ b/libs/include/SFML/Graphics/VertexBuffer.hpp
@@ -1,0 +1,408 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_VERTEXBUFFER_HPP
+#define SFML_VERTEXBUFFER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/PrimitiveType.hpp>
+#include <SFML/Graphics/Drawable.hpp>
+#include <SFML/Window/GlResource.hpp>
+
+
+namespace sf
+{
+class RenderTarget;
+class Vertex;
+
+////////////////////////////////////////////////////////////
+/// \brief Vertex buffer storage for one or more 2D primitives
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API VertexBuffer : public Drawable, private GlResource
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Usage specifiers
+    ///
+    /// If data is going to be updated once or more every frame,
+    /// set the usage to Stream. If data is going to be set once
+    /// and used for a long time without being modified, set the
+    /// usage to Static. For everything else Dynamic should be a
+    /// good compromise.
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Usage
+    {
+        Stream,  ///< Constantly changing data
+        Dynamic, ///< Occasionally changing data
+        Static   ///< Rarely changing data
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty vertex buffer.
+    ///
+    ////////////////////////////////////////////////////////////
+    VertexBuffer();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a VertexBuffer with a specific PrimitiveType
+    ///
+    /// Creates an empty vertex buffer and sets its primitive type to \p type.
+    ///
+    /// \param type Type of primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit VertexBuffer(PrimitiveType type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a VertexBuffer with a specific usage specifier
+    ///
+    /// Creates an empty vertex buffer and sets its usage to \p usage.
+    ///
+    /// \param usage Usage specifier
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit VertexBuffer(Usage usage);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a VertexBuffer with a specific PrimitiveType and usage specifier
+    ///
+    /// Creates an empty vertex buffer and sets its primitive type
+    /// to \p type and usage to \p usage.
+    ///
+    /// \param type  Type of primitive
+    /// \param usage Usage specifier
+    ///
+    ////////////////////////////////////////////////////////////
+    VertexBuffer(PrimitiveType type, Usage usage);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    VertexBuffer(const VertexBuffer& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~VertexBuffer();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the vertex buffer
+    ///
+    /// Creates the vertex buffer and allocates enough graphics
+    /// memory to hold \p vertexCount vertices. Any previously
+    /// allocated memory is freed in the process.
+    ///
+    /// In order to deallocate previously allocated memory pass 0
+    /// as \p vertexCount. Don't forget to recreate with a non-zero
+    /// value when graphics memory should be allocated again.
+    ///
+    /// \param vertexCount Number of vertices worth of memory to allocate
+    ///
+    /// \return True if creation was successful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool create(std::size_t vertexCount);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the vertex count
+    ///
+    /// \return Number of vertices in the vertex buffer
+    ///
+    ////////////////////////////////////////////////////////////
+    std::size_t getVertexCount() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the whole buffer from an array of vertices
+    ///
+    /// The \a vertex array is assumed to have the same size as
+    /// the \a created buffer.
+    ///
+    /// No additional check is performed on the size of the vertex
+    /// array, passing invalid arguments will lead to undefined
+    /// behavior.
+    ///
+    /// This function does nothing if \a vertices is null or if the
+    /// buffer was not previously created.
+    ///
+    /// \param vertices Array of vertices to copy to the buffer
+    ///
+    /// \return True if the update was successful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool update(const Vertex* vertices);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update a part of the buffer from an array of vertices
+    ///
+    /// \p offset is specified as the number of vertices to skip
+    /// from the beginning of the buffer.
+    ///
+    /// If \p offset is 0 and \p vertexCount is equal to the size of
+    /// the currently created buffer, its whole contents are replaced.
+    ///
+    /// If \p offset is 0 and \p vertexCount is greater than the
+    /// size of the currently created buffer, a new buffer is created
+    /// containing the vertex data.
+    ///
+    /// If \p offset is 0 and \p vertexCount is less than the size of
+    /// the currently created buffer, only the corresponding region
+    /// is updated.
+    ///
+    /// If \p offset is not 0 and \p offset + \p vertexCount is greater
+    /// than the size of the currently created buffer, the update fails.
+    ///
+    /// No additional check is performed on the size of the vertex
+    /// array, passing invalid arguments will lead to undefined
+    /// behavior.
+    ///
+    /// \param vertices    Array of vertices to copy to the buffer
+    /// \param vertexCount Number of vertices to copy
+    /// \param offset      Offset in the buffer to copy to
+    ///
+    /// \return True if the update was successful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool update(const Vertex* vertices, std::size_t vertexCount, unsigned int offset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy the contents of another buffer into this buffer
+    ///
+    /// \param vertexBuffer Vertex buffer whose contents to copy into this vertex buffer
+    ///
+    /// \return True if the copy was successful
+    ///
+    ////////////////////////////////////////////////////////////
+    bool update(const VertexBuffer& vertexBuffer);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    VertexBuffer& operator =(const VertexBuffer& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Swap the contents of this vertex buffer with those of another
+    ///
+    /// \param right Instance to swap with
+    ///
+    ////////////////////////////////////////////////////////////
+    void swap(VertexBuffer& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the underlying OpenGL handle of the vertex buffer.
+    ///
+    /// You shouldn't need to use this function, unless you have
+    /// very specific stuff to implement that SFML doesn't support,
+    /// or implement a temporary workaround until a bug is fixed.
+    ///
+    /// \return OpenGL handle of the vertex buffer or 0 if not yet created
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned int getNativeHandle() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the type of primitives to draw
+    ///
+    /// This function defines how the vertices must be interpreted
+    /// when it's time to draw them.
+    ///
+    /// The default primitive type is sf::Points.
+    ///
+    /// \param type Type of primitive
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPrimitiveType(PrimitiveType type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the type of primitives drawn by the vertex buffer
+    ///
+    /// \return Primitive type
+    ///
+    ////////////////////////////////////////////////////////////
+    PrimitiveType getPrimitiveType() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the usage specifier of this vertex buffer
+    ///
+    /// This function provides a hint about how this vertex buffer is
+    /// going to be used in terms of data update frequency.
+    ///
+    /// After changing the usage specifier, the vertex buffer has
+    /// to be updated with new data for the usage specifier to
+    /// take effect.
+    ///
+    /// The default primitive type is sf::VertexBuffer::Stream.
+    ///
+    /// \param usage Usage specifier
+    ///
+    ////////////////////////////////////////////////////////////
+    void setUsage(Usage usage);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the usage specifier of this vertex buffer
+    ///
+    /// \return Usage specifier
+    ///
+    ////////////////////////////////////////////////////////////
+    Usage getUsage() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Bind a vertex buffer for rendering
+    ///
+    /// This function is not part of the graphics API, it mustn't be
+    /// used when drawing SFML entities. It must be used only if you
+    /// mix sf::VertexBuffer with OpenGL code.
+    ///
+    /// \code
+    /// sf::VertexBuffer vb1, vb2;
+    /// ...
+    /// sf::VertexBuffer::bind(&vb1);
+    /// // draw OpenGL stuff that use vb1...
+    /// sf::VertexBuffer::bind(&vb2);
+    /// // draw OpenGL stuff that use vb2...
+    /// sf::VertexBuffer::bind(NULL);
+    /// // draw OpenGL stuff that use no vertex buffer...
+    /// \endcode
+    ///
+    /// \param vertexBuffer Pointer to the vertex buffer to bind, can be null to use no vertex buffer
+    ///
+    ////////////////////////////////////////////////////////////
+    static void bind(const VertexBuffer* vertexBuffer);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the system supports vertex buffers
+    ///
+    /// This function should always be called before using
+    /// the vertex buffer features. If it returns false, then
+    /// any attempt to use sf::VertexBuffer will fail.
+    ///
+    /// \return True if vertex buffers are supported, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isAvailable();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Draw the vertex buffer to a render target
+    ///
+    /// \param target Render target to draw to
+    /// \param states Current render states
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void draw(RenderTarget& target, RenderStates states) const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    unsigned int  m_buffer;        ///< Internal buffer identifier
+    std::size_t   m_size;          ///< Size in Vertexes of the currently allocated buffer
+    PrimitiveType m_primitiveType; ///< Type of primitives to draw
+    Usage         m_usage;         ///< How this vertex buffer is to be used
+};
+
+} // namespace sf
+
+
+#endif // SFML_VERTEXBUFFER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::VertexBuffer
+/// \ingroup graphics
+///
+/// sf::VertexBuffer is a simple wrapper around a dynamic
+/// buffer of vertices and a primitives type.
+///
+/// Unlike sf::VertexArray, the vertex data is stored in
+/// graphics memory.
+///
+/// In situations where a large amount of vertex data would
+/// have to be transferred from system memory to graphics memory
+/// every frame, using sf::VertexBuffer can help. By using a
+/// sf::VertexBuffer, data that has not been changed between frames
+/// does not have to be re-transferred from system to graphics
+/// memory as would be the case with sf::VertexArray. If data transfer
+/// is a bottleneck, this can lead to performance gains.
+///
+/// Using sf::VertexBuffer, the user also has the ability to only modify
+/// a portion of the buffer in graphics memory. This way, a large buffer
+/// can be allocated at the start of the application and only the
+/// applicable portions of it need to be updated during the course of
+/// the application. This allows the user to take full control of data
+/// transfers between system and graphics memory if they need to.
+///
+/// In special cases, the user can make use of multiple threads to update
+/// vertex data in multiple distinct regions of the buffer simultaneously.
+/// This might make sense when e.g. the position of multiple objects has to
+/// be recalculated very frequently. The computation load can be spread
+/// across multiple threads as long as there are no other data dependencies.
+///
+/// Simultaneous updates to the vertex buffer are not guaranteed to be
+/// carried out by the driver in any specific order. Updating the same
+/// region of the buffer from multiple threads will not cause undefined
+/// behaviour, however the final state of the buffer will be unpredictable.
+///
+/// Simultaneous updates of distinct non-overlapping regions of the buffer
+/// are also not guaranteed to complete in a specific order. However, in
+/// this case the user can make sure to synchronize the writer threads at
+/// well-defined points in their code. The driver will make sure that all
+/// pending data transfers complete before the vertex buffer is sourced
+/// by the rendering pipeline.
+///
+/// It inherits sf::Drawable, but unlike other drawables it
+/// is not transformable.
+///
+/// Example:
+/// \code
+/// sf::Vertex vertices[15];
+/// ...
+/// sf::VertexBuffer triangles(sf::Triangles);
+/// triangles.create(15);
+/// triangles.update(vertices);
+/// ...
+/// window.draw(triangles);
+/// \endcode
+///
+/// \see sf::Vertex, sf::VertexArray
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Graphics/View.hpp
+++ b/libs/include/SFML/Graphics/View.hpp
@@ -1,0 +1,343 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_VIEW_HPP
+#define SFML_VIEW_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Graphics/Export.hpp>
+#include <SFML/Graphics/Rect.hpp>
+#include <SFML/Graphics/Transform.hpp>
+#include <SFML/System/Vector2.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief 2D camera that defines what region is shown on screen
+///
+////////////////////////////////////////////////////////////
+class SFML_GRAPHICS_API View
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor creates a default view of (0, 0, 1000, 1000)
+    ///
+    ////////////////////////////////////////////////////////////
+    View();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the view from a rectangle
+    ///
+    /// \param rectangle Rectangle defining the zone to display
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit View(const FloatRect& rectangle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the view from its center and size
+    ///
+    /// \param center Center of the zone to display
+    /// \param size   Size of zone to display
+    ///
+    ////////////////////////////////////////////////////////////
+    View(const Vector2f& center, const Vector2f& size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the center of the view
+    ///
+    /// \param x X coordinate of the new center
+    /// \param y Y coordinate of the new center
+    ///
+    /// \see setSize, getCenter
+    ///
+    ////////////////////////////////////////////////////////////
+    void setCenter(float x, float y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the center of the view
+    ///
+    /// \param center New center
+    ///
+    /// \see setSize, getCenter
+    ///
+    ////////////////////////////////////////////////////////////
+    void setCenter(const Vector2f& center);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the size of the view
+    ///
+    /// \param width  New width of the view
+    /// \param height New height of the view
+    ///
+    /// \see setCenter, getCenter
+    ///
+    ////////////////////////////////////////////////////////////
+    void setSize(float width, float height);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the size of the view
+    ///
+    /// \param size New size
+    ///
+    /// \see setCenter, getCenter
+    ///
+    ////////////////////////////////////////////////////////////
+    void setSize(const Vector2f& size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the orientation of the view
+    ///
+    /// The default rotation of a view is 0 degree.
+    ///
+    /// \param angle New angle, in degrees
+    ///
+    /// \see getRotation
+    ///
+    ////////////////////////////////////////////////////////////
+    void setRotation(float angle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the target viewport
+    ///
+    /// The viewport is the rectangle into which the contents of the
+    /// view are displayed, expressed as a factor (between 0 and 1)
+    /// of the size of the RenderTarget to which the view is applied.
+    /// For example, a view which takes the left side of the target would
+    /// be defined with View.setViewport(sf::FloatRect(0, 0, 0.5, 1)).
+    /// By default, a view has a viewport which covers the entire target.
+    ///
+    /// \param viewport New viewport rectangle
+    ///
+    /// \see getViewport
+    ///
+    ////////////////////////////////////////////////////////////
+    void setViewport(const FloatRect& viewport);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Reset the view to the given rectangle
+    ///
+    /// Note that this function resets the rotation angle to 0.
+    ///
+    /// \param rectangle Rectangle defining the zone to display
+    ///
+    /// \see setCenter, setSize, setRotation
+    ///
+    ////////////////////////////////////////////////////////////
+    void reset(const FloatRect& rectangle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the center of the view
+    ///
+    /// \return Center of the view
+    ///
+    /// \see getSize, setCenter
+    ///
+    ////////////////////////////////////////////////////////////
+    const Vector2f& getCenter() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the size of the view
+    ///
+    /// \return Size of the view
+    ///
+    /// \see getCenter, setSize
+    ///
+    ////////////////////////////////////////////////////////////
+    const Vector2f& getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current orientation of the view
+    ///
+    /// \return Rotation angle of the view, in degrees
+    ///
+    /// \see setRotation
+    ///
+    ////////////////////////////////////////////////////////////
+    float getRotation() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the target viewport rectangle of the view
+    ///
+    /// \return Viewport rectangle, expressed as a factor of the target size
+    ///
+    /// \see setViewport
+    ///
+    ////////////////////////////////////////////////////////////
+    const FloatRect& getViewport() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Move the view relatively to its current position
+    ///
+    /// \param offsetX X coordinate of the move offset
+    /// \param offsetY Y coordinate of the move offset
+    ///
+    /// \see setCenter, rotate, zoom
+    ///
+    ////////////////////////////////////////////////////////////
+    void move(float offsetX, float offsetY);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Move the view relatively to its current position
+    ///
+    /// \param offset Move offset
+    ///
+    /// \see setCenter, rotate, zoom
+    ///
+    ////////////////////////////////////////////////////////////
+    void move(const Vector2f& offset);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Rotate the view relatively to its current orientation
+    ///
+    /// \param angle Angle to rotate, in degrees
+    ///
+    /// \see setRotation, move, zoom
+    ///
+    ////////////////////////////////////////////////////////////
+    void rotate(float angle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Resize the view rectangle relatively to its current size
+    ///
+    /// Resizing the view simulates a zoom, as the zone displayed on
+    /// screen grows or shrinks.
+    /// \a factor is a multiplier:
+    /// \li 1 keeps the size unchanged
+    /// \li > 1 makes the view bigger (objects appear smaller)
+    /// \li < 1 makes the view smaller (objects appear bigger)
+    ///
+    /// \param factor Zoom factor to apply
+    ///
+    /// \see setSize, move, rotate
+    ///
+    ////////////////////////////////////////////////////////////
+    void zoom(float factor);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the projection transform of the view
+    ///
+    /// This function is meant for internal use only.
+    ///
+    /// \return Projection transform defining the view
+    ///
+    /// \see getInverseTransform
+    ///
+    ////////////////////////////////////////////////////////////
+    const Transform& getTransform() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the inverse projection transform of the view
+    ///
+    /// This function is meant for internal use only.
+    ///
+    /// \return Inverse of the projection transform defining the view
+    ///
+    /// \see getTransform
+    ///
+    ////////////////////////////////////////////////////////////
+    const Transform& getInverseTransform() const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Vector2f          m_center;              ///< Center of the view, in scene coordinates
+    Vector2f          m_size;                ///< Size of the view, in scene coordinates
+    float             m_rotation;            ///< Angle of rotation of the view rectangle, in degrees
+    FloatRect         m_viewport;            ///< Viewport rectangle, expressed as a factor of the render-target's size
+    mutable Transform m_transform;           ///< Precomputed projection transform corresponding to the view
+    mutable Transform m_inverseTransform;    ///< Precomputed inverse projection transform corresponding to the view
+    mutable bool      m_transformUpdated;    ///< Internal state telling if the transform needs to be updated
+    mutable bool      m_invTransformUpdated; ///< Internal state telling if the inverse transform needs to be updated
+};
+
+} // namespace sf
+
+
+#endif // SFML_VIEW_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::View
+/// \ingroup graphics
+///
+/// sf::View defines a camera in the 2D scene. This is a
+/// very powerful concept: you can scroll, rotate or zoom
+/// the entire scene without altering the way that your
+/// drawable objects are drawn.
+///
+/// A view is composed of a source rectangle, which defines
+/// what part of the 2D scene is shown, and a target viewport,
+/// which defines where the contents of the source rectangle
+/// will be displayed on the render target (window or texture).
+///
+/// The viewport allows to map the scene to a custom part
+/// of the render target, and can be used for split-screen
+/// or for displaying a minimap, for example. If the source
+/// rectangle doesn't have the same size as the viewport, its
+/// contents will be stretched to fit in.
+///
+/// To apply a view, you have to assign it to the render target.
+/// Then, objects drawn in this render target will be
+/// affected by the view until you use another view.
+///
+/// Usage example:
+/// \code
+/// sf::RenderWindow window;
+/// sf::View view;
+///
+/// // Initialize the view to a rectangle located at (100, 100) and with a size of 400x200
+/// view.reset(sf::FloatRect(100, 100, 400, 200));
+///
+/// // Rotate it by 45 degrees
+/// view.rotate(45);
+///
+/// // Set its target viewport to be half of the window
+/// view.setViewport(sf::FloatRect(0.f, 0.f, 0.5f, 1.f));
+///
+/// // Apply it
+/// window.setView(view);
+///
+/// // Render stuff
+/// window.draw(someSprite);
+///
+/// // Set the default view back
+/// window.setView(window.getDefaultView());
+///
+/// // Render stuff not affected by the view
+/// window.draw(someText);
+/// \endcode
+///
+/// See also the note on coordinates and undistorted rendering in sf::Transformable.
+///
+/// \see sf::RenderWindow, sf::RenderTexture
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Main.hpp
+++ b/libs/include/SFML/Main.hpp
@@ -1,0 +1,43 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_MAIN_HPP
+#define SFML_MAIN_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+#if defined(SFML_SYSTEM_IOS)
+
+    // On iOS, we have no choice but to have our own main,
+    // so we need to rename the user one and call it later
+    #define main sfmlMain
+
+#endif
+
+
+#endif // SFML_MAIN_HPP

--- a/libs/include/SFML/Network.hpp
+++ b/libs/include/SFML/Network.hpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_NETWORK_HPP
+#define SFML_NETWORK_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
+#include <SFML/System.hpp>
+#include <SFML/Network/Ftp.hpp>
+#include <SFML/Network/Http.hpp>
+#include <SFML/Network/IpAddress.hpp>
+#include <SFML/Network/Packet.hpp>
+#include <SFML/Network/Socket.hpp>
+#include <SFML/Network/SocketHandle.hpp>
+#include <SFML/Network/SocketSelector.hpp>
+#include <SFML/Network/TcpListener.hpp>
+#include <SFML/Network/TcpSocket.hpp>
+#include <SFML/Network/UdpSocket.hpp>
+
+
+#endif // SFML_NETWORK_HPP
+
+////////////////////////////////////////////////////////////
+/// \defgroup network Network module
+///
+/// Socket-based communication, utilities and higher-level
+/// network protocols (HTTP, FTP).
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/Export.hpp
+++ b/libs/include/SFML/Network/Export.hpp
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_NETWORK_EXPORT_HPP
+#define SFML_NETWORK_EXPORT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+////////////////////////////////////////////////////////////
+// Define portable import / export macros
+////////////////////////////////////////////////////////////
+#if defined(SFML_NETWORK_EXPORTS)
+
+    #define SFML_NETWORK_API SFML_API_EXPORT
+
+#else
+
+    #define SFML_NETWORK_API SFML_API_IMPORT
+
+#endif
+
+
+#endif // SFML_NETWORK_EXPORT_HPP

--- a/libs/include/SFML/Network/Ftp.hpp
+++ b/libs/include/SFML/Network/Ftp.hpp
@@ -1,0 +1,616 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_FTP_HPP
+#define SFML_FTP_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <SFML/Network/TcpSocket.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/Time.hpp>
+#include <string>
+#include <vector>
+
+
+namespace sf
+{
+class IpAddress;
+
+////////////////////////////////////////////////////////////
+/// \brief A FTP client
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API Ftp : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enumeration of transfer modes
+    ///
+    ////////////////////////////////////////////////////////////
+    enum TransferMode
+    {
+        Binary, ///< Binary mode (file is transfered as a sequence of bytes)
+        Ascii,  ///< Text mode using ASCII encoding
+        Ebcdic  ///< Text mode using EBCDIC encoding
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Define a FTP response
+    ///
+    ////////////////////////////////////////////////////////////
+    class SFML_NETWORK_API Response
+    {
+    public:
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Status codes possibly returned by a FTP response
+        ///
+        ////////////////////////////////////////////////////////////
+        enum Status
+        {
+            // 1xx: the requested action is being initiated,
+            // expect another reply before proceeding with a new command
+            RestartMarkerReply          = 110, ///< Restart marker reply
+            ServiceReadySoon            = 120, ///< Service ready in N minutes
+            DataConnectionAlreadyOpened = 125, ///< Data connection already opened, transfer starting
+            OpeningDataConnection       = 150, ///< File status ok, about to open data connection
+
+            // 2xx: the requested action has been successfully completed
+            Ok                    = 200, ///< Command ok
+            PointlessCommand      = 202, ///< Command not implemented
+            SystemStatus          = 211, ///< System status, or system help reply
+            DirectoryStatus       = 212, ///< Directory status
+            FileStatus            = 213, ///< File status
+            HelpMessage           = 214, ///< Help message
+            SystemType            = 215, ///< NAME system type, where NAME is an official system name from the list in the Assigned Numbers document
+            ServiceReady          = 220, ///< Service ready for new user
+            ClosingConnection     = 221, ///< Service closing control connection
+            DataConnectionOpened  = 225, ///< Data connection open, no transfer in progress
+            ClosingDataConnection = 226, ///< Closing data connection, requested file action successful
+            EnteringPassiveMode   = 227, ///< Entering passive mode
+            LoggedIn              = 230, ///< User logged in, proceed. Logged out if appropriate
+            FileActionOk          = 250, ///< Requested file action ok
+            DirectoryOk           = 257, ///< PATHNAME created
+
+            // 3xx: the command has been accepted, but the requested action
+            // is dormant, pending receipt of further information
+            NeedPassword       = 331, ///< User name ok, need password
+            NeedAccountToLogIn = 332, ///< Need account for login
+            NeedInformation    = 350, ///< Requested file action pending further information
+
+            // 4xx: the command was not accepted and the requested action did not take place,
+            // but the error condition is temporary and the action may be requested again
+            ServiceUnavailable        = 421, ///< Service not available, closing control connection
+            DataConnectionUnavailable = 425, ///< Can't open data connection
+            TransferAborted           = 426, ///< Connection closed, transfer aborted
+            FileActionAborted         = 450, ///< Requested file action not taken
+            LocalError                = 451, ///< Requested action aborted, local error in processing
+            InsufficientStorageSpace  = 452, ///< Requested action not taken; insufficient storage space in system, file unavailable
+
+            // 5xx: the command was not accepted and
+            // the requested action did not take place
+            CommandUnknown          = 500, ///< Syntax error, command unrecognized
+            ParametersUnknown       = 501, ///< Syntax error in parameters or arguments
+            CommandNotImplemented   = 502, ///< Command not implemented
+            BadCommandSequence      = 503, ///< Bad sequence of commands
+            ParameterNotImplemented = 504, ///< Command not implemented for that parameter
+            NotLoggedIn             = 530, ///< Not logged in
+            NeedAccountToStore      = 532, ///< Need account for storing files
+            FileUnavailable         = 550, ///< Requested action not taken, file unavailable
+            PageTypeUnknown         = 551, ///< Requested action aborted, page type unknown
+            NotEnoughMemory         = 552, ///< Requested file action aborted, exceeded storage allocation
+            FilenameNotAllowed      = 553, ///< Requested action not taken, file name not allowed
+
+            // 10xx: SFML custom codes
+            InvalidResponse  = 1000, ///< Not part of the FTP standard, generated by SFML when a received response cannot be parsed
+            ConnectionFailed = 1001, ///< Not part of the FTP standard, generated by SFML when the low-level socket connection with the server fails
+            ConnectionClosed = 1002, ///< Not part of the FTP standard, generated by SFML when the low-level socket connection is unexpectedly closed
+            InvalidFile      = 1003  ///< Not part of the FTP standard, generated by SFML when a local file cannot be read or written
+        };
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        /// This constructor is used by the FTP client to build
+        /// the response.
+        ///
+        /// \param code    Response status code
+        /// \param message Response message
+        ///
+        ////////////////////////////////////////////////////////////
+        explicit Response(Status code = InvalidResponse, const std::string& message = "");
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Check if the status code means a success
+        ///
+        /// This function is defined for convenience, it is
+        /// equivalent to testing if the status code is < 400.
+        ///
+        /// \return True if the status is a success, false if it is a failure
+        ///
+        ////////////////////////////////////////////////////////////
+        bool isOk() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Get the status code of the response
+        ///
+        /// \return Status code
+        ///
+        ////////////////////////////////////////////////////////////
+        Status getStatus() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Get the full message contained in the response
+        ///
+        /// \return The response message
+        ///
+        ////////////////////////////////////////////////////////////
+        const std::string& getMessage() const;
+
+    private:
+
+        ////////////////////////////////////////////////////////////
+        // Member data
+        ////////////////////////////////////////////////////////////
+        Status      m_status;  ///< Status code returned from the server
+        std::string m_message; ///< Last message received from the server
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specialization of FTP response returning a directory
+    ///
+    ////////////////////////////////////////////////////////////
+    class SFML_NETWORK_API DirectoryResponse : public Response
+    {
+    public:
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        /// \param response Source response
+        ///
+        ////////////////////////////////////////////////////////////
+        DirectoryResponse(const Response& response);
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Get the directory returned in the response
+        ///
+        /// \return Directory name
+        ///
+        ////////////////////////////////////////////////////////////
+        const std::string& getDirectory() const;
+
+    private:
+
+        ////////////////////////////////////////////////////////////
+        // Member data
+        ////////////////////////////////////////////////////////////
+        std::string m_directory; ///< Directory extracted from the response message
+    };
+
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Specialization of FTP response returning a
+    ///        filename listing
+    ////////////////////////////////////////////////////////////
+    class SFML_NETWORK_API ListingResponse : public Response
+    {
+    public:
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        /// \param response  Source response
+        /// \param data      Data containing the raw listing
+        ///
+        ////////////////////////////////////////////////////////////
+        ListingResponse(const Response& response, const std::string& data);
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Return the array of directory/file names
+        ///
+        /// \return Array containing the requested listing
+        ///
+        ////////////////////////////////////////////////////////////
+        const std::vector<std::string>& getListing() const;
+
+    private:
+
+        ////////////////////////////////////////////////////////////
+        // Member data
+        ////////////////////////////////////////////////////////////
+        std::vector<std::string> m_listing; ///< Directory/file names extracted from the data
+    };
+
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// Automatically closes the connection with the server if
+    /// it is still opened.
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Ftp();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Connect to the specified FTP server
+    ///
+    /// The port has a default value of 21, which is the standard
+    /// port used by the FTP protocol. You shouldn't use a different
+    /// value, unless you really know what you do.
+    /// This function tries to connect to the server so it may take
+    /// a while to complete, especially if the server is not
+    /// reachable. To avoid blocking your application for too long,
+    /// you can use a timeout. The default value, Time::Zero, means that the
+    /// system timeout will be used (which is usually pretty long).
+    ///
+    /// \param server  Name or address of the FTP server to connect to
+    /// \param port    Port used for the connection
+    /// \param timeout Maximum time to wait
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see disconnect
+    ///
+    ////////////////////////////////////////////////////////////
+    Response connect(const IpAddress& server, unsigned short port = 21, Time timeout = Time::Zero);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Close the connection with the server
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see connect
+    ///
+    ////////////////////////////////////////////////////////////
+    Response disconnect();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Log in using an anonymous account
+    ///
+    /// Logging in is mandatory after connecting to the server.
+    /// Users that are not logged in cannot perform any operation.
+    ///
+    /// \return Server response to the request
+    ///
+    ////////////////////////////////////////////////////////////
+    Response login();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Log in using a username and a password
+    ///
+    /// Logging in is mandatory after connecting to the server.
+    /// Users that are not logged in cannot perform any operation.
+    ///
+    /// \param name     User name
+    /// \param password Password
+    ///
+    /// \return Server response to the request
+    ///
+    ////////////////////////////////////////////////////////////
+    Response login(const std::string& name, const std::string& password);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Send a null command to keep the connection alive
+    ///
+    /// This command is useful because the server may close the
+    /// connection automatically if no command is sent.
+    ///
+    /// \return Server response to the request
+    ///
+    ////////////////////////////////////////////////////////////
+    Response keepAlive();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current working directory
+    ///
+    /// The working directory is the root path for subsequent
+    /// operations involving directories and/or filenames.
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see getDirectoryListing, changeDirectory, parentDirectory
+    ///
+    ////////////////////////////////////////////////////////////
+    DirectoryResponse getWorkingDirectory();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the contents of the given directory
+    ///
+    /// This function retrieves the sub-directories and files
+    /// contained in the given directory. It is not recursive.
+    /// The \a directory parameter is relative to the current
+    /// working directory.
+    ///
+    /// \param directory Directory to list
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see getWorkingDirectory, changeDirectory, parentDirectory
+    ///
+    ////////////////////////////////////////////////////////////
+    ListingResponse getDirectoryListing(const std::string& directory = "");
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current working directory
+    ///
+    /// The new directory must be relative to the current one.
+    ///
+    /// \param directory New working directory
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see getWorkingDirectory, getDirectoryListing, parentDirectory
+    ///
+    ////////////////////////////////////////////////////////////
+    Response changeDirectory(const std::string& directory);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Go to the parent directory of the current one
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see getWorkingDirectory, getDirectoryListing, changeDirectory
+    ///
+    ////////////////////////////////////////////////////////////
+    Response parentDirectory();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a new directory
+    ///
+    /// The new directory is created as a child of the current
+    /// working directory.
+    ///
+    /// \param name Name of the directory to create
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see deleteDirectory
+    ///
+    ////////////////////////////////////////////////////////////
+    Response createDirectory(const std::string& name);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Remove an existing directory
+    ///
+    /// The directory to remove must be relative to the
+    /// current working directory.
+    /// Use this function with caution, the directory will
+    /// be removed permanently!
+    ///
+    /// \param name Name of the directory to remove
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see createDirectory
+    ///
+    ////////////////////////////////////////////////////////////
+    Response deleteDirectory(const std::string& name);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Rename an existing file
+    ///
+    /// The filenames must be relative to the current working
+    /// directory.
+    ///
+    /// \param file    File to rename
+    /// \param newName New name of the file
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see deleteFile
+    ///
+    ////////////////////////////////////////////////////////////
+    Response renameFile(const std::string& file, const std::string& newName);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Remove an existing file
+    ///
+    /// The file name must be relative to the current working
+    /// directory.
+    /// Use this function with caution, the file will be
+    /// removed permanently!
+    ///
+    /// \param name File to remove
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see renameFile
+    ///
+    ////////////////////////////////////////////////////////////
+    Response deleteFile(const std::string& name);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Download a file from the server
+    ///
+    /// The filename of the distant file is relative to the
+    /// current working directory of the server, and the local
+    /// destination path is relative to the current directory
+    /// of your application.
+    /// If a file with the same filename as the distant file
+    /// already exists in the local destination path, it will
+    /// be overwritten.
+    ///
+    /// \param remoteFile Filename of the distant file to download
+    /// \param localPath  The directory in which to put the file on the local computer
+    /// \param mode       Transfer mode
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see upload
+    ///
+    ////////////////////////////////////////////////////////////
+    Response download(const std::string& remoteFile, const std::string& localPath, TransferMode mode = Binary);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Upload a file to the server
+    ///
+    /// The name of the local file is relative to the current
+    /// working directory of your application, and the
+    /// remote path is relative to the current directory of the
+    /// FTP server.
+    ///
+    /// The append parameter controls whether the remote file is
+    /// appended to or overwritten if it already exists.
+    ///
+    /// \param localFile  Path of the local file to upload
+    /// \param remotePath The directory in which to put the file on the server
+    /// \param mode       Transfer mode
+    /// \param append     Pass true to append to or false to overwrite the remote file if it already exists
+    ///
+    /// \return Server response to the request
+    ///
+    /// \see download
+    ///
+    ////////////////////////////////////////////////////////////
+    Response upload(const std::string& localFile, const std::string& remotePath, TransferMode mode = Binary, bool append = false);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Send a command to the FTP server
+    ///
+    /// While the most often used commands are provided as member
+    /// functions in the sf::Ftp class, this method can be used
+    /// to send any FTP command to the server. If the command
+    /// requires one or more parameters, they can be specified
+    /// in \a parameter. If the server returns information, you
+    /// can extract it from the response using Response::getMessage().
+    ///
+    /// \param command   Command to send
+    /// \param parameter Command parameter
+    ///
+    /// \return Server response to the request
+    ///
+    ////////////////////////////////////////////////////////////
+    Response sendCommand(const std::string& command, const std::string& parameter = "");
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Receive a response from the server
+    ///
+    /// This function must be called after each call to
+    /// sendCommand that expects a response.
+    ///
+    /// \return Server response to the request
+    ///
+    ////////////////////////////////////////////////////////////
+    Response getResponse();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Utility class for exchanging datas with the server
+    ///        on the data channel
+    ///
+    ////////////////////////////////////////////////////////////
+    class DataChannel;
+
+    friend class DataChannel;
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    TcpSocket   m_commandSocket; ///< Socket holding the control connection with the server
+    std::string m_receiveBuffer; ///< Received command data that is yet to be processed
+};
+
+} // namespace sf
+
+
+#endif // SFML_FTP_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Ftp
+/// \ingroup network
+///
+/// sf::Ftp is a very simple FTP client that allows you
+/// to communicate with a FTP server. The FTP protocol allows
+/// you to manipulate a remote file system (list files,
+/// upload, download, create, remove, ...).
+///
+/// Using the FTP client consists of 4 parts:
+/// \li Connecting to the FTP server
+/// \li Logging in (either as a registered user or anonymously)
+/// \li Sending commands to the server
+/// \li Disconnecting (this part can be done implicitly by the destructor)
+///
+/// Every command returns a FTP response, which contains the
+/// status code as well as a message from the server. Some
+/// commands such as getWorkingDirectory() and getDirectoryListing()
+/// return additional data, and use a class derived from
+/// sf::Ftp::Response to provide this data. The most often used
+/// commands are directly provided as member functions, but it is
+/// also possible to use specific commands with the sendCommand() function.
+///
+/// Note that response statuses >= 1000 are not part of the FTP standard,
+/// they are generated by SFML when an internal error occurs.
+///
+/// All commands, especially upload and download, may take some
+/// time to complete. This is important to know if you don't want
+/// to block your application while the server is completing
+/// the task.
+///
+/// Usage example:
+/// \code
+/// // Create a new FTP client
+/// sf::Ftp ftp;
+///
+/// // Connect to the server
+/// sf::Ftp::Response response = ftp.connect("ftp://ftp.myserver.com");
+/// if (response.isOk())
+///     std::cout << "Connected" << std::endl;
+///
+/// // Log in
+/// response = ftp.login("laurent", "dF6Zm89D");
+/// if (response.isOk())
+///     std::cout << "Logged in" << std::endl;
+///
+/// // Print the working directory
+/// sf::Ftp::DirectoryResponse directory = ftp.getWorkingDirectory();
+/// if (directory.isOk())
+///     std::cout << "Working directory: " << directory.getDirectory() << std::endl;
+///
+/// // Create a new directory
+/// response = ftp.createDirectory("files");
+/// if (response.isOk())
+///     std::cout << "Created new directory" << std::endl;
+///
+/// // Upload a file to this new directory
+/// response = ftp.upload("local-path/file.txt", "files", sf::Ftp::Ascii);
+/// if (response.isOk())
+///     std::cout << "File uploaded" << std::endl;
+///
+/// // Send specific commands (here: FEAT to list supported FTP features)
+/// response = ftp.sendCommand("FEAT");
+/// if (response.isOk())
+///     std::cout << "Feature list:\n" << response.getMessage() << std::endl;
+///
+/// // Disconnect from the server (optional)
+/// ftp.disconnect();
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/Http.hpp
+++ b/libs/include/SFML/Network/Http.hpp
@@ -1,0 +1,482 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_HTTP_HPP
+#define SFML_HTTP_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <SFML/Network/IpAddress.hpp>
+#include <SFML/Network/TcpSocket.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/Time.hpp>
+#include <map>
+#include <string>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief A HTTP client
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API Http : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Define a HTTP request
+    ///
+    ////////////////////////////////////////////////////////////
+    class SFML_NETWORK_API Request
+    {
+    public:
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Enumerate the available HTTP methods for a request
+        ///
+        ////////////////////////////////////////////////////////////
+        enum Method
+        {
+            Get,   ///< Request in get mode, standard method to retrieve a page
+            Post,  ///< Request in post mode, usually to send data to a page
+            Head,  ///< Request a page's header only
+            Put,   ///< Request in put mode, useful for a REST API
+            Delete ///< Request in delete mode, useful for a REST API
+        };
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        /// This constructor creates a GET request, with the root
+        /// URI ("/") and an empty body.
+        ///
+        /// \param uri    Target URI
+        /// \param method Method to use for the request
+        /// \param body   Content of the request's body
+        ///
+        ////////////////////////////////////////////////////////////
+        Request(const std::string& uri = "/", Method method = Get, const std::string& body = "");
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Set the value of a field
+        ///
+        /// The field is created if it doesn't exist. The name of
+        /// the field is case-insensitive.
+        /// By default, a request doesn't contain any field (but the
+        /// mandatory fields are added later by the HTTP client when
+        /// sending the request).
+        ///
+        /// \param field Name of the field to set
+        /// \param value Value of the field
+        ///
+        ////////////////////////////////////////////////////////////
+        void setField(const std::string& field, const std::string& value);
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Set the request method
+        ///
+        /// See the Method enumeration for a complete list of all
+        /// the availale methods.
+        /// The method is Http::Request::Get by default.
+        ///
+        /// \param method Method to use for the request
+        ///
+        ////////////////////////////////////////////////////////////
+        void setMethod(Method method);
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Set the requested URI
+        ///
+        /// The URI is the resource (usually a web page or a file)
+        /// that you want to get or post.
+        /// The URI is "/" (the root page) by default.
+        ///
+        /// \param uri URI to request, relative to the host
+        ///
+        ////////////////////////////////////////////////////////////
+        void setUri(const std::string& uri);
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Set the HTTP version for the request
+        ///
+        /// The HTTP version is 1.0 by default.
+        ///
+        /// \param major Major HTTP version number
+        /// \param minor Minor HTTP version number
+        ///
+        ////////////////////////////////////////////////////////////
+        void setHttpVersion(unsigned int major, unsigned int minor);
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Set the body of the request
+        ///
+        /// The body of a request is optional and only makes sense
+        /// for POST requests. It is ignored for all other methods.
+        /// The body is empty by default.
+        ///
+        /// \param body Content of the body
+        ///
+        ////////////////////////////////////////////////////////////
+        void setBody(const std::string& body);
+
+    private:
+
+        friend class Http;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Prepare the final request to send to the server
+        ///
+        /// This is used internally by Http before sending the
+        /// request to the web server.
+        ///
+        /// \return String containing the request, ready to be sent
+        ///
+        ////////////////////////////////////////////////////////////
+        std::string prepare() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Check if the request defines a field
+        ///
+        /// This function uses case-insensitive comparisons.
+        ///
+        /// \param field Name of the field to test
+        ///
+        /// \return True if the field exists, false otherwise
+        ///
+        ////////////////////////////////////////////////////////////
+        bool hasField(const std::string& field) const;
+
+        ////////////////////////////////////////////////////////////
+        // Types
+        ////////////////////////////////////////////////////////////
+        typedef std::map<std::string, std::string> FieldTable;
+
+        ////////////////////////////////////////////////////////////
+        // Member data
+        ////////////////////////////////////////////////////////////
+        FieldTable   m_fields;       ///< Fields of the header associated to their value
+        Method       m_method;       ///< Method to use for the request
+        std::string  m_uri;          ///< Target URI of the request
+        unsigned int m_majorVersion; ///< Major HTTP version
+        unsigned int m_minorVersion; ///< Minor HTTP version
+        std::string  m_body;         ///< Body of the request
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Define a HTTP response
+    ///
+    ////////////////////////////////////////////////////////////
+    class SFML_NETWORK_API Response
+    {
+    public:
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Enumerate all the valid status codes for a response
+        ///
+        ////////////////////////////////////////////////////////////
+        enum Status
+        {
+            // 2xx: success
+            Ok             = 200, ///< Most common code returned when operation was successful
+            Created        = 201, ///< The resource has successfully been created
+            Accepted       = 202, ///< The request has been accepted, but will be processed later by the server
+            NoContent      = 204, ///< The server didn't send any data in return
+            ResetContent   = 205, ///< The server informs the client that it should clear the view (form) that caused the request to be sent
+            PartialContent = 206, ///< The server has sent a part of the resource, as a response to a partial GET request
+
+            // 3xx: redirection
+            MultipleChoices  = 300, ///< The requested page can be accessed from several locations
+            MovedPermanently = 301, ///< The requested page has permanently moved to a new location
+            MovedTemporarily = 302, ///< The requested page has temporarily moved to a new location
+            NotModified      = 304, ///< For conditional requests, means the requested page hasn't changed and doesn't need to be refreshed
+
+            // 4xx: client error
+            BadRequest          = 400, ///< The server couldn't understand the request (syntax error)
+            Unauthorized        = 401, ///< The requested page needs an authentication to be accessed
+            Forbidden           = 403, ///< The requested page cannot be accessed at all, even with authentication
+            NotFound            = 404, ///< The requested page doesn't exist
+            RangeNotSatisfiable = 407, ///< The server can't satisfy the partial GET request (with a "Range" header field)
+
+            // 5xx: server error
+            InternalServerError = 500, ///< The server encountered an unexpected error
+            NotImplemented      = 501, ///< The server doesn't implement a requested feature
+            BadGateway          = 502, ///< The gateway server has received an error from the source server
+            ServiceNotAvailable = 503, ///< The server is temporarily unavailable (overloaded, in maintenance, ...)
+            GatewayTimeout      = 504, ///< The gateway server couldn't receive a response from the source server
+            VersionNotSupported = 505, ///< The server doesn't support the requested HTTP version
+
+            // 10xx: SFML custom codes
+            InvalidResponse  = 1000, ///< Response is not a valid HTTP one
+            ConnectionFailed = 1001  ///< Connection with server failed
+        };
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        /// Constructs an empty response.
+        ///
+        ////////////////////////////////////////////////////////////
+        Response();
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Get the value of a field
+        ///
+        /// If the field \a field is not found in the response header,
+        /// the empty string is returned. This function uses
+        /// case-insensitive comparisons.
+        ///
+        /// \param field Name of the field to get
+        ///
+        /// \return Value of the field, or empty string if not found
+        ///
+        ////////////////////////////////////////////////////////////
+        const std::string& getField(const std::string& field) const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Get the response status code
+        ///
+        /// The status code should be the first thing to be checked
+        /// after receiving a response, it defines whether it is a
+        /// success, a failure or anything else (see the Status
+        /// enumeration).
+        ///
+        /// \return Status code of the response
+        ///
+        ////////////////////////////////////////////////////////////
+        Status getStatus() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Get the major HTTP version number of the response
+        ///
+        /// \return Major HTTP version number
+        ///
+        /// \see getMinorHttpVersion
+        ///
+        ////////////////////////////////////////////////////////////
+        unsigned int getMajorHttpVersion() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Get the minor HTTP version number of the response
+        ///
+        /// \return Minor HTTP version number
+        ///
+        /// \see getMajorHttpVersion
+        ///
+        ////////////////////////////////////////////////////////////
+        unsigned int getMinorHttpVersion() const;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Get the body of the response
+        ///
+        /// The body of a response may contain:
+        /// \li the requested page (for GET requests)
+        /// \li a response from the server (for POST requests)
+        /// \li nothing (for HEAD requests)
+        /// \li an error message (in case of an error)
+        ///
+        /// \return The response body
+        ///
+        ////////////////////////////////////////////////////////////
+        const std::string& getBody() const;
+
+    private:
+
+        friend class Http;
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Construct the header from a response string
+        ///
+        /// This function is used by Http to build the response
+        /// of a request.
+        ///
+        /// \param data Content of the response to parse
+        ///
+        ////////////////////////////////////////////////////////////
+        void parse(const std::string& data);
+
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Read values passed in the answer header
+        ///
+        /// This function is used by Http to extract values passed
+        /// in the response.
+        ///
+        /// \param in String stream containing the header values
+        ///
+        ////////////////////////////////////////////////////////////
+        void parseFields(std::istream &in);
+
+        ////////////////////////////////////////////////////////////
+        // Types
+        ////////////////////////////////////////////////////////////
+        typedef std::map<std::string, std::string> FieldTable;
+
+        ////////////////////////////////////////////////////////////
+        // Member data
+        ////////////////////////////////////////////////////////////
+        FieldTable   m_fields;       ///< Fields of the header
+        Status       m_status;       ///< Status code
+        unsigned int m_majorVersion; ///< Major HTTP version
+        unsigned int m_minorVersion; ///< Minor HTTP version
+        std::string  m_body;         ///< Body of the response
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Http();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the HTTP client with the target host
+    ///
+    /// This is equivalent to calling setHost(host, port).
+    /// The port has a default value of 0, which means that the
+    /// HTTP client will use the right port according to the
+    /// protocol used (80 for HTTP). You should leave it like
+    /// this unless you really need a port other than the
+    /// standard one, or use an unknown protocol.
+    ///
+    /// \param host Web server to connect to
+    /// \param port Port to use for connection
+    ///
+    ////////////////////////////////////////////////////////////
+    Http(const std::string& host, unsigned short port = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the target host
+    ///
+    /// This function just stores the host address and port, it
+    /// doesn't actually connect to it until you send a request.
+    /// The port has a default value of 0, which means that the
+    /// HTTP client will use the right port according to the
+    /// protocol used (80 for HTTP). You should leave it like
+    /// this unless you really need a port other than the
+    /// standard one, or use an unknown protocol.
+    ///
+    /// \param host Web server to connect to
+    /// \param port Port to use for connection
+    ///
+    ////////////////////////////////////////////////////////////
+    void setHost(const std::string& host, unsigned short port = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Send a HTTP request and return the server's response.
+    ///
+    /// You must have a valid host before sending a request (see setHost).
+    /// Any missing mandatory header field in the request will be added
+    /// with an appropriate value.
+    /// Warning: this function waits for the server's response and may
+    /// not return instantly; use a thread if you don't want to block your
+    /// application, or use a timeout to limit the time to wait. A value
+    /// of Time::Zero means that the client will use the system default timeout
+    /// (which is usually pretty long).
+    ///
+    /// \param request Request to send
+    /// \param timeout Maximum time to wait
+    ///
+    /// \return Server's response
+    ///
+    ////////////////////////////////////////////////////////////
+    Response sendRequest(const Request& request, Time timeout = Time::Zero);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    TcpSocket      m_connection; ///< Connection to the host
+    IpAddress      m_host;       ///< Web host address
+    std::string    m_hostName;   ///< Web host name
+    unsigned short m_port;       ///< Port used for connection with host
+};
+
+} // namespace sf
+
+
+#endif // SFML_HTTP_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Http
+/// \ingroup network
+///
+/// sf::Http is a very simple HTTP client that allows you
+/// to communicate with a web server. You can retrieve
+/// web pages, send data to an interactive resource,
+/// download a remote file, etc. The HTTPS protocol is
+/// not supported.
+///
+/// The HTTP client is split into 3 classes:
+/// \li sf::Http::Request
+/// \li sf::Http::Response
+/// \li sf::Http
+///
+/// sf::Http::Request builds the request that will be
+/// sent to the server. A request is made of:
+/// \li a method (what you want to do)
+/// \li a target URI (usually the name of the web page or file)
+/// \li one or more header fields (options that you can pass to the server)
+/// \li an optional body (for POST requests)
+///
+/// sf::Http::Response parse the response from the web server
+/// and provides getters to read them. The response contains:
+/// \li a status code
+/// \li header fields (that may be answers to the ones that you requested)
+/// \li a body, which contains the contents of the requested resource
+///
+/// sf::Http provides a simple function, SendRequest, to send a
+/// sf::Http::Request and return the corresponding sf::Http::Response
+/// from the server.
+///
+/// Usage example:
+/// \code
+/// // Create a new HTTP client
+/// sf::Http http;
+///
+/// // We'll work on http://www.sfml-dev.org
+/// http.setHost("http://www.sfml-dev.org");
+///
+/// // Prepare a request to get the 'features.php' page
+/// sf::Http::Request request("features.php");
+///
+/// // Send the request
+/// sf::Http::Response response = http.sendRequest(request);
+///
+/// // Check the status code and display the result
+/// sf::Http::Response::Status status = response.getStatus();
+/// if (status == sf::Http::Response::Ok)
+/// {
+///     std::cout << response.getBody() << std::endl;
+/// }
+/// else
+/// {
+///     std::cout << "Error " << status << std::endl;
+/// }
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/IpAddress.hpp
+++ b/libs/include/SFML/Network/IpAddress.hpp
@@ -1,0 +1,328 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_IPADDRESS_HPP
+#define SFML_IPADDRESS_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <SFML/System/Time.hpp>
+#include <istream>
+#include <ostream>
+#include <string>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Encapsulate an IPv4 network address
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API IpAddress
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor creates an empty (invalid) address
+    ///
+    ////////////////////////////////////////////////////////////
+    IpAddress();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the address from a string
+    ///
+    /// Here \a address can be either a decimal address
+    /// (ex: "192.168.1.56") or a network name (ex: "localhost").
+    ///
+    /// \param address IP address or network name
+    ///
+    ////////////////////////////////////////////////////////////
+    IpAddress(const std::string& address);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the address from a string
+    ///
+    /// Here \a address can be either a decimal address
+    /// (ex: "192.168.1.56") or a network name (ex: "localhost").
+    /// This is equivalent to the constructor taking a std::string
+    /// parameter, it is defined for convenience so that the
+    /// implicit conversions from literal strings to IpAddress work.
+    ///
+    /// \param address IP address or network name
+    ///
+    ////////////////////////////////////////////////////////////
+    IpAddress(const char* address);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the address from 4 bytes
+    ///
+    /// Calling IpAddress(a, b, c, d) is equivalent to calling
+    /// IpAddress("a.b.c.d"), but safer as it doesn't have to
+    /// parse a string to get the address components.
+    ///
+    /// \param byte0 First byte of the address
+    /// \param byte1 Second byte of the address
+    /// \param byte2 Third byte of the address
+    /// \param byte3 Fourth byte of the address
+    ///
+    ////////////////////////////////////////////////////////////
+    IpAddress(Uint8 byte0, Uint8 byte1, Uint8 byte2, Uint8 byte3);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the address from a 32-bits integer
+    ///
+    /// This constructor uses the internal representation of
+    /// the address directly. It should be used for optimization
+    /// purposes, and only if you got that representation from
+    /// IpAddress::toInteger().
+    ///
+    /// \param address 4 bytes of the address packed into a 32-bits integer
+    ///
+    /// \see toInteger
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit IpAddress(Uint32 address);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a string representation of the address
+    ///
+    /// The returned string is the decimal representation of the
+    /// IP address (like "192.168.1.56"), even if it was constructed
+    /// from a host name.
+    ///
+    /// \return String representation of the address
+    ///
+    /// \see toInteger
+    ///
+    ////////////////////////////////////////////////////////////
+    std::string toString() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get an integer representation of the address
+    ///
+    /// The returned number is the internal representation of the
+    /// address, and should be used for optimization purposes only
+    /// (like sending the address through a socket).
+    /// The integer produced by this function can then be converted
+    /// back to a sf::IpAddress with the proper constructor.
+    ///
+    /// \return 32-bits unsigned integer representation of the address
+    ///
+    /// \see toString
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint32 toInteger() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the computer's local address
+    ///
+    /// The local address is the address of the computer from the
+    /// LAN point of view, i.e. something like 192.168.1.56. It is
+    /// meaningful only for communications over the local network.
+    /// Unlike getPublicAddress, this function is fast and may be
+    /// used safely anywhere.
+    ///
+    /// \return Local IP address of the computer
+    ///
+    /// \see getPublicAddress
+    ///
+    ////////////////////////////////////////////////////////////
+    static IpAddress getLocalAddress();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the computer's public address
+    ///
+    /// The public address is the address of the computer from the
+    /// internet point of view, i.e. something like 89.54.1.169.
+    /// It is necessary for communications over the world wide web.
+    /// The only way to get a public address is to ask it to a
+    /// distant website; as a consequence, this function depends on
+    /// both your network connection and the server, and may be
+    /// very slow. You should use it as few as possible. Because
+    /// this function depends on the network connection and on a distant
+    /// server, you may use a time limit if you don't want your program
+    /// to be possibly stuck waiting in case there is a problem; this
+    /// limit is deactivated by default.
+    ///
+    /// \param timeout Maximum time to wait
+    ///
+    /// \return Public IP address of the computer
+    ///
+    /// \see getLocalAddress
+    ///
+    ////////////////////////////////////////////////////////////
+    static IpAddress getPublicAddress(Time timeout = Time::Zero);
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static const IpAddress None;      ///< Value representing an empty/invalid address
+    static const IpAddress Any;       ///< Value representing any address (0.0.0.0)
+    static const IpAddress LocalHost; ///< The "localhost" address (for connecting a computer to itself locally)
+    static const IpAddress Broadcast; ///< The "broadcast" address (for sending UDP messages to everyone on a local network)
+
+private:
+
+    friend SFML_NETWORK_API bool operator <(const IpAddress& left, const IpAddress& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Resolve the given address string
+    ///
+    /// \param address Address string
+    ///
+    ////////////////////////////////////////////////////////////
+    void resolve(const std::string& address);
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Uint32 m_address; ///< Address stored as an unsigned 32 bits integer
+    bool   m_valid;   ///< Is the address valid?
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Overload of == operator to compare two IP addresses
+///
+/// \param left  Left operand (a IP address)
+/// \param right Right operand (a IP address)
+///
+/// \return True if both addresses are equal
+///
+////////////////////////////////////////////////////////////
+SFML_NETWORK_API bool operator ==(const IpAddress& left, const IpAddress& right);
+
+////////////////////////////////////////////////////////////
+/// \brief Overload of != operator to compare two IP addresses
+///
+/// \param left  Left operand (a IP address)
+/// \param right Right operand (a IP address)
+///
+/// \return True if both addresses are different
+///
+////////////////////////////////////////////////////////////
+SFML_NETWORK_API bool operator !=(const IpAddress& left, const IpAddress& right);
+
+////////////////////////////////////////////////////////////
+/// \brief Overload of < operator to compare two IP addresses
+///
+/// \param left  Left operand (a IP address)
+/// \param right Right operand (a IP address)
+///
+/// \return True if \a left is lesser than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_NETWORK_API bool operator <(const IpAddress& left, const IpAddress& right);
+
+////////////////////////////////////////////////////////////
+/// \brief Overload of > operator to compare two IP addresses
+///
+/// \param left  Left operand (a IP address)
+/// \param right Right operand (a IP address)
+///
+/// \return True if \a left is greater than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_NETWORK_API bool operator >(const IpAddress& left, const IpAddress& right);
+
+////////////////////////////////////////////////////////////
+/// \brief Overload of <= operator to compare two IP addresses
+///
+/// \param left  Left operand (a IP address)
+/// \param right Right operand (a IP address)
+///
+/// \return True if \a left is lesser or equal than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_NETWORK_API bool operator <=(const IpAddress& left, const IpAddress& right);
+
+////////////////////////////////////////////////////////////
+/// \brief Overload of >= operator to compare two IP addresses
+///
+/// \param left  Left operand (a IP address)
+/// \param right Right operand (a IP address)
+///
+/// \return True if \a left is greater or equal than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_NETWORK_API bool operator >=(const IpAddress& left, const IpAddress& right);
+
+////////////////////////////////////////////////////////////
+/// \brief Overload of >> operator to extract an IP address from an input stream
+///
+/// \param stream  Input stream
+/// \param address IP address to extract
+///
+/// \return Reference to the input stream
+///
+////////////////////////////////////////////////////////////
+SFML_NETWORK_API std::istream& operator >>(std::istream& stream, IpAddress& address);
+
+////////////////////////////////////////////////////////////
+/// \brief Overload of << operator to print an IP address to an output stream
+///
+/// \param stream  Output stream
+/// \param address IP address to print
+///
+/// \return Reference to the output stream
+///
+////////////////////////////////////////////////////////////
+SFML_NETWORK_API std::ostream& operator <<(std::ostream& stream, const IpAddress& address);
+
+} // namespace sf
+
+
+#endif // SFML_IPADDRESS_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::IpAddress
+/// \ingroup network
+///
+/// sf::IpAddress is a utility class for manipulating network
+/// addresses. It provides a set a implicit constructors and
+/// conversion functions to easily build or transform an IP
+/// address from/to various representations.
+///
+/// Usage example:
+/// \code
+/// sf::IpAddress a0;                                     // an invalid address
+/// sf::IpAddress a1 = sf::IpAddress::None;               // an invalid address (same as a0)
+/// sf::IpAddress a2("127.0.0.1");                        // the local host address
+/// sf::IpAddress a3 = sf::IpAddress::Broadcast;          // the broadcast address
+/// sf::IpAddress a4(192, 168, 1, 56);                    // a local address
+/// sf::IpAddress a5("my_computer");                      // a local address created from a network name
+/// sf::IpAddress a6("89.54.1.169");                      // a distant address
+/// sf::IpAddress a7("www.google.com");                   // a distant address created from a network name
+/// sf::IpAddress a8 = sf::IpAddress::getLocalAddress();  // my address on the local network
+/// sf::IpAddress a9 = sf::IpAddress::getPublicAddress(); // my address on the internet
+/// \endcode
+///
+/// Note that sf::IpAddress currently doesn't support IPv6
+/// nor other types of network addresses.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/Packet.hpp
+++ b/libs/include/SFML/Network/Packet.hpp
@@ -1,0 +1,532 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_PACKET_HPP
+#define SFML_PACKET_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <string>
+#include <vector>
+
+
+namespace sf
+{
+class String;
+class TcpSocket;
+class UdpSocket;
+
+////////////////////////////////////////////////////////////
+/// \brief Utility class to build blocks of data to transfer
+///        over the network
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API Packet
+{
+    // A bool-like type that cannot be converted to integer or pointer types
+    typedef bool (Packet::*BoolType)(std::size_t);
+
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates an empty packet.
+    ///
+    ////////////////////////////////////////////////////////////
+    Packet();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Virtual destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~Packet();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Append data to the end of the packet
+    ///
+    /// \param data        Pointer to the sequence of bytes to append
+    /// \param sizeInBytes Number of bytes to append
+    ///
+    /// \see clear
+    ///
+    ////////////////////////////////////////////////////////////
+    void append(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clear the packet
+    ///
+    /// After calling Clear, the packet is empty.
+    ///
+    /// \see append
+    ///
+    ////////////////////////////////////////////////////////////
+    void clear();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a pointer to the data contained in the packet
+    ///
+    /// Warning: the returned pointer may become invalid after
+    /// you append data to the packet, therefore it should never
+    /// be stored.
+    /// The return pointer is NULL if the packet is empty.
+    ///
+    /// \return Pointer to the data
+    ///
+    /// \see getDataSize
+    ///
+    ////////////////////////////////////////////////////////////
+    const void* getData() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the size of the data contained in the packet
+    ///
+    /// This function returns the number of bytes pointed to by
+    /// what getData returns.
+    ///
+    /// \return Data size, in bytes
+    ///
+    /// \see getData
+    ///
+    ////////////////////////////////////////////////////////////
+    std::size_t getDataSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell if the reading position has reached the
+    ///        end of the packet
+    ///
+    /// This function is useful to know if there is some data
+    /// left to be read, without actually reading it.
+    ///
+    /// \return True if all data was read, false otherwise
+    ///
+    /// \see operator bool
+    ///
+    ////////////////////////////////////////////////////////////
+    bool endOfPacket() const;
+
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Test the validity of the packet, for reading
+    ///
+    /// This operator allows to test the packet as a boolean
+    /// variable, to check if a reading operation was successful.
+    ///
+    /// A packet will be in an invalid state if it has no more
+    /// data to read.
+    ///
+    /// This behavior is the same as standard C++ streams.
+    ///
+    /// Usage example:
+    /// \code
+    /// float x;
+    /// packet >> x;
+    /// if (packet)
+    /// {
+    ///    // ok, x was extracted successfully
+    /// }
+    ///
+    /// // -- or --
+    ///
+    /// float x;
+    /// if (packet >> x)
+    /// {
+    ///    // ok, x was extracted successfully
+    /// }
+    /// \endcode
+    ///
+    /// Don't focus on the return type, it's equivalent to bool but
+    /// it disallows unwanted implicit conversions to integer or
+    /// pointer types.
+    ///
+    /// \return True if last data extraction from packet was successful
+    ///
+    /// \see endOfPacket
+    ///
+    ////////////////////////////////////////////////////////////
+    operator BoolType() const;
+
+    ////////////////////////////////////////////////////////////
+    /// Overload of operator >> to read data from the packet
+    ///
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(bool&         data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(Int8&         data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(Uint8&        data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(Int16&        data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(Uint16&       data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(Int32&        data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(Uint32&       data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(Int64&        data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(Uint64&       data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(float&        data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(double&       data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(char*         data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(std::string&  data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(wchar_t*      data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(std::wstring& data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator >>(String&       data);
+
+    ////////////////////////////////////////////////////////////
+    /// Overload of operator << to write data into the packet
+    ///
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(bool                data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(Int8                data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(Uint8               data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(Int16               data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(Uint16              data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(Int32               data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(Uint32              data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(Int64               data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(Uint64              data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(float               data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(double              data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(const char*         data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(const std::string&  data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(const wchar_t*      data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(const std::wstring& data);
+
+    ////////////////////////////////////////////////////////////
+    /// \overload
+    ////////////////////////////////////////////////////////////
+    Packet& operator <<(const String&       data);
+
+protected:
+
+    friend class TcpSocket;
+    friend class UdpSocket;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Called before the packet is sent over the network
+    ///
+    /// This function can be defined by derived classes to
+    /// transform the data before it is sent; this can be
+    /// used for compression, encryption, etc.
+    /// The function must return a pointer to the modified data,
+    /// as well as the number of bytes pointed.
+    /// The default implementation provides the packet's data
+    /// without transforming it.
+    ///
+    /// \param size Variable to fill with the size of data to send
+    ///
+    /// \return Pointer to the array of bytes to send
+    ///
+    /// \see onReceive
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual const void* onSend(std::size_t& size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Called after the packet is received over the network
+    ///
+    /// This function can be defined by derived classes to
+    /// transform the data after it is received; this can be
+    /// used for decompression, decryption, etc.
+    /// The function receives a pointer to the received data,
+    /// and must fill the packet with the transformed bytes.
+    /// The default implementation fills the packet directly
+    /// without transforming the data.
+    ///
+    /// \param data Pointer to the received bytes
+    /// \param size Number of bytes
+    ///
+    /// \see onSend
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onReceive(const void* data, std::size_t size);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// Disallow comparisons between packets
+    ///
+    ////////////////////////////////////////////////////////////
+    bool operator ==(const Packet& right) const;
+    bool operator !=(const Packet& right) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if the packet can extract a given number of bytes
+    ///
+    /// This function updates accordingly the state of the packet.
+    ///
+    /// \param size Size to check
+    ///
+    /// \return True if \a size bytes can be read from the packet
+    ///
+    ////////////////////////////////////////////////////////////
+    bool checkSize(std::size_t size);
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::vector<char> m_data;    ///< Data stored in the packet
+    std::size_t       m_readPos; ///< Current reading position in the packet
+    std::size_t       m_sendPos; ///< Current send position in the packet (for handling partial sends)
+    bool              m_isValid; ///< Reading state of the packet
+};
+
+} // namespace sf
+
+
+#endif // SFML_PACKET_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Packet
+/// \ingroup network
+///
+/// Packets provide a safe and easy way to serialize data,
+/// in order to send it over the network using sockets
+/// (sf::TcpSocket, sf::UdpSocket).
+///
+/// Packets solve 2 fundamental problems that arise when
+/// transferring data over the network:
+/// \li data is interpreted correctly according to the endianness
+/// \li the bounds of the packet are preserved (one send == one receive)
+///
+/// The sf::Packet class provides both input and output modes.
+/// It is designed to follow the behavior of standard C++ streams,
+/// using operators >> and << to extract and insert data.
+///
+/// It is recommended to use only fixed-size types (like sf::Int32, etc.),
+/// to avoid possible differences between the sender and the receiver.
+/// Indeed, the native C++ types may have different sizes on two platforms
+/// and your data may be corrupted if that happens.
+///
+/// Usage example:
+/// \code
+/// sf::Uint32 x = 24;
+/// std::string s = "hello";
+/// double d = 5.89;
+///
+/// // Group the variables to send into a packet
+/// sf::Packet packet;
+/// packet << x << s << d;
+///
+/// // Send it over the network (socket is a valid sf::TcpSocket)
+/// socket.send(packet);
+///
+/// -----------------------------------------------------------------
+///
+/// // Receive the packet at the other end
+/// sf::Packet packet;
+/// socket.receive(packet);
+///
+/// // Extract the variables contained in the packet
+/// sf::Uint32 x;
+/// std::string s;
+/// double d;
+/// if (packet >> x >> s >> d)
+/// {
+///     // Data extracted successfully...
+/// }
+/// \endcode
+///
+/// Packets have built-in operator >> and << overloads for
+/// standard types:
+/// \li bool
+/// \li fixed-size integer types (sf::Int8/16/32, sf::Uint8/16/32)
+/// \li floating point numbers (float, double)
+/// \li string types (char*, wchar_t*, std::string, std::wstring, sf::String)
+///
+/// Like standard streams, it is also possible to define your own
+/// overloads of operators >> and << in order to handle your
+/// custom types.
+///
+/// \code
+/// struct MyStruct
+/// {
+///     float       number;
+///     sf::Int8    integer;
+///     std::string str;
+/// };
+///
+/// sf::Packet& operator <<(sf::Packet& packet, const MyStruct& m)
+/// {
+///     return packet << m.number << m.integer << m.str;
+/// }
+///
+/// sf::Packet& operator >>(sf::Packet& packet, MyStruct& m)
+/// {
+///     return packet >> m.number >> m.integer >> m.str;
+/// }
+/// \endcode
+///
+/// Packets also provide an extra feature that allows to apply
+/// custom transformations to the data before it is sent,
+/// and after it is received. This is typically used to
+/// handle automatic compression or encryption of the data.
+/// This is achieved by inheriting from sf::Packet, and overriding
+/// the onSend and onReceive functions.
+///
+/// Here is an example:
+/// \code
+/// class ZipPacket : public sf::Packet
+/// {
+///     virtual const void* onSend(std::size_t& size)
+///     {
+///         const void* srcData = getData();
+///         std::size_t srcSize = getDataSize();
+///
+///         return MySuperZipFunction(srcData, srcSize, &size);
+///     }
+///
+///     virtual void onReceive(const void* data, std::size_t size)
+///     {
+///         std::size_t dstSize;
+///         const void* dstData = MySuperUnzipFunction(data, size, &dstSize);
+///
+///         append(dstData, dstSize);
+///     }
+/// };
+///
+/// // Use like regular packets:
+/// ZipPacket packet;
+/// packet << x << s << d;
+/// ...
+/// \endcode
+///
+/// \see sf::TcpSocket, sf::UdpSocket
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/Socket.hpp
+++ b/libs/include/SFML/Network/Socket.hpp
@@ -1,0 +1,219 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOCKET_HPP
+#define SFML_SOCKET_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <SFML/Network/SocketHandle.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <vector>
+
+
+namespace sf
+{
+class SocketSelector;
+
+////////////////////////////////////////////////////////////
+/// \brief Base class for all the socket types
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API Socket : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Status codes that may be returned by socket functions
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Status
+    {
+        Done,         ///< The socket has sent / received the data
+        NotReady,     ///< The socket is not ready to send / receive data yet
+        Partial,      ///< The socket sent a part of the data
+        Disconnected, ///< The TCP socket has been disconnected
+        Error         ///< An unexpected error happened
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Some special values used by sockets
+    ///
+    ////////////////////////////////////////////////////////////
+    enum
+    {
+        AnyPort = 0 ///< Special value that tells the system to pick any available port
+    };
+
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~Socket();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the blocking state of the socket
+    ///
+    /// In blocking mode, calls will not return until they have
+    /// completed their task. For example, a call to Receive in
+    /// blocking mode won't return until some data was actually
+    /// received.
+    /// In non-blocking mode, calls will always return immediately,
+    /// using the return code to signal whether there was data
+    /// available or not.
+    /// By default, all sockets are blocking.
+    ///
+    /// \param blocking True to set the socket as blocking, false for non-blocking
+    ///
+    /// \see isBlocking
+    ///
+    ////////////////////////////////////////////////////////////
+    void setBlocking(bool blocking);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether the socket is in blocking or non-blocking mode
+    ///
+    /// \return True if the socket is blocking, false otherwise
+    ///
+    /// \see setBlocking
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isBlocking() const;
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Types of protocols that the socket can use
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Type
+    {
+        Tcp, ///< TCP protocol
+        Udp  ///< UDP protocol
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor can only be accessed by derived classes.
+    ///
+    /// \param type Type of the socket (TCP or UDP)
+    ///
+    ////////////////////////////////////////////////////////////
+    Socket(Type type);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the internal handle of the socket
+    ///
+    /// The returned handle may be invalid if the socket
+    /// was not created yet (or already destroyed).
+    /// This function can only be accessed by derived classes.
+    ///
+    /// \return The internal (OS-specific) handle of the socket
+    ///
+    ////////////////////////////////////////////////////////////
+    SocketHandle getHandle() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the internal representation of the socket
+    ///
+    /// This function can only be accessed by derived classes.
+    ///
+    ////////////////////////////////////////////////////////////
+    void create();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create the internal representation of the socket
+    ///        from a socket handle
+    ///
+    /// This function can only be accessed by derived classes.
+    ///
+    /// \param handle OS-specific handle of the socket to wrap
+    ///
+    ////////////////////////////////////////////////////////////
+    void create(SocketHandle handle);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Close the socket gracefully
+    ///
+    /// This function can only be accessed by derived classes.
+    ///
+    ////////////////////////////////////////////////////////////
+    void close();
+
+private:
+
+    friend class SocketSelector;
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Type         m_type;       ///< Type of the socket (TCP or UDP)
+    SocketHandle m_socket;     ///< Socket descriptor
+    bool         m_isBlocking; ///< Current blocking mode of the socket
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOCKET_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Socket
+/// \ingroup network
+///
+/// This class mainly defines internal stuff to be used by
+/// derived classes.
+///
+/// The only public features that it defines, and which
+/// is therefore common to all the socket classes, is the
+/// blocking state. All sockets can be set as blocking or
+/// non-blocking.
+///
+/// In blocking mode, socket functions will hang until
+/// the operation completes, which means that the entire
+/// program (well, in fact the current thread if you use
+/// multiple ones) will be stuck waiting for your socket
+/// operation to complete.
+///
+/// In non-blocking mode, all the socket functions will
+/// return immediately. If the socket is not ready to complete
+/// the requested operation, the function simply returns
+/// the proper status code (Socket::NotReady).
+///
+/// The default mode, which is blocking, is the one that is
+/// generally used, in combination with threads or selectors.
+/// The non-blocking mode is rather used in real-time
+/// applications that run an endless loop that can poll
+/// the socket often enough, and cannot afford blocking
+/// this loop.
+///
+/// \see sf::TcpListener, sf::TcpSocket, sf::UdpSocket
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/SocketHandle.hpp
+++ b/libs/include/SFML/Network/SocketHandle.hpp
@@ -1,0 +1,57 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOCKETHANDLE_HPP
+#define SFML_SOCKETHANDLE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+#if defined(SFML_SYSTEM_WINDOWS)
+    #include <basetsd.h>
+#endif
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+// Define the low-level socket handle type, specific to
+// each platform
+////////////////////////////////////////////////////////////
+#if defined(SFML_SYSTEM_WINDOWS)
+
+    typedef UINT_PTR SocketHandle;
+
+#else
+
+    typedef int SocketHandle;
+
+#endif
+
+} // namespace sf
+
+
+#endif // SFML_SOCKETHANDLE_HPP

--- a/libs/include/SFML/Network/SocketSelector.hpp
+++ b/libs/include/SFML/Network/SocketSelector.hpp
@@ -1,0 +1,263 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SOCKETSELECTOR_HPP
+#define SFML_SOCKETSELECTOR_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <SFML/System/Time.hpp>
+
+
+namespace sf
+{
+class Socket;
+
+////////////////////////////////////////////////////////////
+/// \brief Multiplexer that allows to read from multiple sockets
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API SocketSelector
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    SocketSelector();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    SocketSelector(const SocketSelector& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~SocketSelector();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Add a new socket to the selector
+    ///
+    /// This function keeps a weak reference to the socket,
+    /// so you have to make sure that the socket is not destroyed
+    /// while it is stored in the selector.
+    /// This function does nothing if the socket is not valid.
+    ///
+    /// \param socket Reference to the socket to add
+    ///
+    /// \see remove, clear
+    ///
+    ////////////////////////////////////////////////////////////
+    void add(Socket& socket);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Remove a socket from the selector
+    ///
+    /// This function doesn't destroy the socket, it simply
+    /// removes the reference that the selector has to it.
+    ///
+    /// \param socket Reference to the socket to remove
+    ///
+    /// \see add, clear
+    ///
+    ////////////////////////////////////////////////////////////
+    void remove(Socket& socket);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Remove all the sockets stored in the selector
+    ///
+    /// This function doesn't destroy any instance, it simply
+    /// removes all the references that the selector has to
+    /// external sockets.
+    ///
+    /// \see add, remove
+    ///
+    ////////////////////////////////////////////////////////////
+    void clear();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Wait until one or more sockets are ready to receive
+    ///
+    /// This function returns as soon as at least one socket has
+    /// some data available to be received. To know which sockets are
+    /// ready, use the isReady function.
+    /// If you use a timeout and no socket is ready before the timeout
+    /// is over, the function returns false.
+    ///
+    /// \param timeout Maximum time to wait, (use Time::Zero for infinity)
+    ///
+    /// \return True if there are sockets ready, false otherwise
+    ///
+    /// \see isReady
+    ///
+    ////////////////////////////////////////////////////////////
+    bool wait(Time timeout = Time::Zero);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Test a socket to know if it is ready to receive data
+    ///
+    /// This function must be used after a call to Wait, to know
+    /// which sockets are ready to receive data. If a socket is
+    /// ready, a call to receive will never block because we know
+    /// that there is data available to read.
+    /// Note that if this function returns true for a TcpListener,
+    /// this means that it is ready to accept a new connection.
+    ///
+    /// \param socket Socket to test
+    ///
+    /// \return True if the socket is ready to read, false otherwise
+    ///
+    /// \see isReady
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isReady(Socket& socket) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    SocketSelector& operator =(const SocketSelector& right);
+
+private:
+
+    struct SocketSelectorImpl;
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    SocketSelectorImpl* m_impl; ///< Opaque pointer to the implementation (which requires OS-specific types)
+};
+
+} // namespace sf
+
+
+#endif // SFML_SOCKETSELECTOR_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::SocketSelector
+/// \ingroup network
+///
+/// Socket selectors provide a way to wait until some data is
+/// available on a set of sockets, instead of just one. This
+/// is convenient when you have multiple sockets that may
+/// possibly receive data, but you don't know which one will
+/// be ready first. In particular, it avoids to use a thread
+/// for each socket; with selectors, a single thread can handle
+/// all the sockets.
+///
+/// All types of sockets can be used in a selector:
+/// \li sf::TcpListener
+/// \li sf::TcpSocket
+/// \li sf::UdpSocket
+///
+/// A selector doesn't store its own copies of the sockets
+/// (socket classes are not copyable anyway), it simply keeps
+/// a reference to the original sockets that you pass to the
+/// "add" function. Therefore, you can't use the selector as a
+/// socket container, you must store them outside and make sure
+/// that they are alive as long as they are used in the selector.
+///
+/// Using a selector is simple:
+/// \li populate the selector with all the sockets that you want to observe
+/// \li make it wait until there is data available on any of the sockets
+/// \li test each socket to find out which ones are ready
+///
+/// Usage example:
+/// \code
+/// // Create a socket to listen to new connections
+/// sf::TcpListener listener;
+/// listener.listen(55001);
+///
+/// // Create a list to store the future clients
+/// std::list<sf::TcpSocket*> clients;
+///
+/// // Create a selector
+/// sf::SocketSelector selector;
+///
+/// // Add the listener to the selector
+/// selector.add(listener);
+///
+/// // Endless loop that waits for new connections
+/// while (running)
+/// {
+///     // Make the selector wait for data on any socket
+///     if (selector.wait())
+///     {
+///         // Test the listener
+///         if (selector.isReady(listener))
+///         {
+///             // The listener is ready: there is a pending connection
+///             sf::TcpSocket* client = new sf::TcpSocket;
+///             if (listener.accept(*client) == sf::Socket::Done)
+///             {
+///                 // Add the new client to the clients list
+///                 clients.push_back(client);
+///
+///                 // Add the new client to the selector so that we will
+///                 // be notified when he sends something
+///                 selector.add(*client);
+///             }
+///             else
+///             {
+///                 // Error, we won't get a new connection, delete the socket
+///                 delete client;
+///             }
+///         }
+///         else
+///         {
+///             // The listener socket is not ready, test all other sockets (the clients)
+///             for (std::list<sf::TcpSocket*>::iterator it = clients.begin(); it != clients.end(); ++it)
+///             {
+///                 sf::TcpSocket& client = **it;
+///                 if (selector.isReady(client))
+///                 {
+///                     // The client has sent some data, we can receive it
+///                     sf::Packet packet;
+///                     if (client.receive(packet) == sf::Socket::Done)
+///                     {
+///                         ...
+///                     }
+///                 }
+///             }
+///         }
+///     }
+/// }
+/// \endcode
+///
+/// \see sf::Socket
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/TcpListener.hpp
+++ b/libs/include/SFML/Network/TcpListener.hpp
@@ -1,0 +1,166 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_TCPLISTENER_HPP
+#define SFML_TCPLISTENER_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <SFML/Network/Socket.hpp>
+#include <SFML/Network/IpAddress.hpp>
+
+
+namespace sf
+{
+class TcpSocket;
+
+////////////////////////////////////////////////////////////
+/// \brief Socket that listens to new TCP connections
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API TcpListener : public Socket
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    TcpListener();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the port to which the socket is bound locally
+    ///
+    /// If the socket is not listening to a port, this function
+    /// returns 0.
+    ///
+    /// \return Port to which the socket is bound
+    ///
+    /// \see listen
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned short getLocalPort() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Start listening for incoming connection attempts
+    ///
+    /// This function makes the socket start listening on the
+    /// specified port, waiting for incoming connection attempts.
+    ///
+    /// If the socket is already listening on a port when this
+    /// function is called, it will stop listening on the old
+    /// port before starting to listen on the new port.
+    ///
+    /// \param port    Port to listen on for incoming connection attempts
+    /// \param address Address of the interface to listen on
+    ///
+    /// \return Status code
+    ///
+    /// \see accept, close
+    ///
+    ////////////////////////////////////////////////////////////
+    Status listen(unsigned short port, const IpAddress& address = IpAddress::Any);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Stop listening and close the socket
+    ///
+    /// This function gracefully stops the listener. If the
+    /// socket is not listening, this function has no effect.
+    ///
+    /// \see listen
+    ///
+    ////////////////////////////////////////////////////////////
+    void close();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Accept a new connection
+    ///
+    /// If the socket is in blocking mode, this function will
+    /// not return until a connection is actually received.
+    ///
+    /// \param socket Socket that will hold the new connection
+    ///
+    /// \return Status code
+    ///
+    /// \see listen
+    ///
+    ////////////////////////////////////////////////////////////
+    Status accept(TcpSocket& socket);
+};
+
+
+} // namespace sf
+
+
+#endif // SFML_TCPLISTENER_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::TcpListener
+/// \ingroup network
+///
+/// A listener socket is a special type of socket that listens to
+/// a given port and waits for connections on that port.
+/// This is all it can do.
+///
+/// When a new connection is received, you must call accept and
+/// the listener returns a new instance of sf::TcpSocket that
+/// is properly initialized and can be used to communicate with
+/// the new client.
+///
+/// Listener sockets are specific to the TCP protocol,
+/// UDP sockets are connectionless and can therefore communicate
+/// directly. As a consequence, a listener socket will always
+/// return the new connections as sf::TcpSocket instances.
+///
+/// A listener is automatically closed on destruction, like all
+/// other types of socket. However if you want to stop listening
+/// before the socket is destroyed, you can call its close()
+/// function.
+///
+/// Usage example:
+/// \code
+/// // Create a listener socket and make it wait for new
+/// // connections on port 55001
+/// sf::TcpListener listener;
+/// listener.listen(55001);
+///
+/// // Endless loop that waits for new connections
+/// while (running)
+/// {
+///     sf::TcpSocket client;
+///     if (listener.accept(client) == sf::Socket::Done)
+///     {
+///         // A new client just connected!
+///         std::cout << "New connection received from " << client.getRemoteAddress() << std::endl;
+///         doSomethingWith(client);
+///     }
+/// }
+/// \endcode
+///
+/// \see sf::TcpSocket, sf::Socket
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/TcpSocket.hpp
+++ b/libs/include/SFML/Network/TcpSocket.hpp
@@ -1,0 +1,316 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_TCPSOCKET_HPP
+#define SFML_TCPSOCKET_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <SFML/Network/Socket.hpp>
+#include <SFML/System/Time.hpp>
+
+
+namespace sf
+{
+class TcpListener;
+class IpAddress;
+class Packet;
+
+////////////////////////////////////////////////////////////
+/// \brief Specialized socket using the TCP protocol
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API TcpSocket : public Socket
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    TcpSocket();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the port to which the socket is bound locally
+    ///
+    /// If the socket is not connected, this function returns 0.
+    ///
+    /// \return Port to which the socket is bound
+    ///
+    /// \see connect, getRemotePort
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned short getLocalPort() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the address of the connected peer
+    ///
+    /// It the socket is not connected, this function returns
+    /// sf::IpAddress::None.
+    ///
+    /// \return Address of the remote peer
+    ///
+    /// \see getRemotePort
+    ///
+    ////////////////////////////////////////////////////////////
+    IpAddress getRemoteAddress() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the port of the connected peer to which
+    ///        the socket is connected
+    ///
+    /// If the socket is not connected, this function returns 0.
+    ///
+    /// \return Remote port to which the socket is connected
+    ///
+    /// \see getRemoteAddress
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned short getRemotePort() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Connect the socket to a remote peer
+    ///
+    /// In blocking mode, this function may take a while, especially
+    /// if the remote peer is not reachable. The last parameter allows
+    /// you to stop trying to connect after a given timeout.
+    /// If the socket is already connected, the connection is
+    /// forcibly disconnected before attempting to connect again.
+    ///
+    /// \param remoteAddress Address of the remote peer
+    /// \param remotePort    Port of the remote peer
+    /// \param timeout       Optional maximum time to wait
+    ///
+    /// \return Status code
+    ///
+    /// \see disconnect
+    ///
+    ////////////////////////////////////////////////////////////
+    Status connect(const IpAddress& remoteAddress, unsigned short remotePort, Time timeout = Time::Zero);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Disconnect the socket from its remote peer
+    ///
+    /// This function gracefully closes the connection. If the
+    /// socket is not connected, this function has no effect.
+    ///
+    /// \see connect
+    ///
+    ////////////////////////////////////////////////////////////
+    void disconnect();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Send raw data to the remote peer
+    ///
+    /// To be able to handle partial sends over non-blocking
+    /// sockets, use the send(const void*, std::size_t, std::size_t&)
+    /// overload instead.
+    /// This function will fail if the socket is not connected.
+    ///
+    /// \param data Pointer to the sequence of bytes to send
+    /// \param size Number of bytes to send
+    ///
+    /// \return Status code
+    ///
+    /// \see receive
+    ///
+    ////////////////////////////////////////////////////////////
+    Status send(const void* data, std::size_t size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Send raw data to the remote peer
+    ///
+    /// This function will fail if the socket is not connected.
+    ///
+    /// \param data Pointer to the sequence of bytes to send
+    /// \param size Number of bytes to send
+    /// \param sent The number of bytes sent will be written here
+    ///
+    /// \return Status code
+    ///
+    /// \see receive
+    ///
+    ////////////////////////////////////////////////////////////
+    Status send(const void* data, std::size_t size, std::size_t& sent);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Receive raw data from the remote peer
+    ///
+    /// In blocking mode, this function will wait until some
+    /// bytes are actually received.
+    /// This function will fail if the socket is not connected.
+    ///
+    /// \param data     Pointer to the array to fill with the received bytes
+    /// \param size     Maximum number of bytes that can be received
+    /// \param received This variable is filled with the actual number of bytes received
+    ///
+    /// \return Status code
+    ///
+    /// \see send
+    ///
+    ////////////////////////////////////////////////////////////
+    Status receive(void* data, std::size_t size, std::size_t& received);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Send a formatted packet of data to the remote peer
+    ///
+    /// In non-blocking mode, if this function returns sf::Socket::Partial,
+    /// you \em must retry sending the same unmodified packet before sending
+    /// anything else in order to guarantee the packet arrives at the remote
+    /// peer uncorrupted.
+    /// This function will fail if the socket is not connected.
+    ///
+    /// \param packet Packet to send
+    ///
+    /// \return Status code
+    ///
+    /// \see receive
+    ///
+    ////////////////////////////////////////////////////////////
+    Status send(Packet& packet);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Receive a formatted packet of data from the remote peer
+    ///
+    /// In blocking mode, this function will wait until the whole packet
+    /// has been received.
+    /// This function will fail if the socket is not connected.
+    ///
+    /// \param packet Packet to fill with the received data
+    ///
+    /// \return Status code
+    ///
+    /// \see send
+    ///
+    ////////////////////////////////////////////////////////////
+    Status receive(Packet& packet);
+
+private:
+
+    friend class TcpListener;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Structure holding the data of a pending packet
+    ///
+    ////////////////////////////////////////////////////////////
+    struct PendingPacket
+    {
+        PendingPacket();
+
+        Uint32            Size;         ///< Data of packet size
+        std::size_t       SizeReceived; ///< Number of size bytes received so far
+        std::vector<char> Data;         ///< Data of the packet
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    PendingPacket m_pendingPacket; ///< Temporary data of the packet currently being received
+};
+
+} // namespace sf
+
+
+#endif // SFML_TCPSOCKET_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::TcpSocket
+/// \ingroup network
+///
+/// TCP is a connected protocol, which means that a TCP
+/// socket can only communicate with the host it is connected
+/// to. It can't send or receive anything if it is not connected.
+///
+/// The TCP protocol is reliable but adds a slight overhead.
+/// It ensures that your data will always be received in order
+/// and without errors (no data corrupted, lost or duplicated).
+///
+/// When a socket is connected to a remote host, you can
+/// retrieve informations about this host with the
+/// getRemoteAddress and getRemotePort functions. You can
+/// also get the local port to which the socket is bound
+/// (which is automatically chosen when the socket is connected),
+/// with the getLocalPort function.
+///
+/// Sending and receiving data can use either the low-level
+/// or the high-level functions. The low-level functions
+/// process a raw sequence of bytes, and cannot ensure that
+/// one call to Send will exactly match one call to Receive
+/// at the other end of the socket.
+///
+/// The high-level interface uses packets (see sf::Packet),
+/// which are easier to use and provide more safety regarding
+/// the data that is exchanged. You can look at the sf::Packet
+/// class to get more details about how they work.
+///
+/// The socket is automatically disconnected when it is destroyed,
+/// but if you want to explicitly close the connection while
+/// the socket instance is still alive, you can call disconnect.
+///
+/// Usage example:
+/// \code
+/// // ----- The client -----
+///
+/// // Create a socket and connect it to 192.168.1.50 on port 55001
+/// sf::TcpSocket socket;
+/// socket.connect("192.168.1.50", 55001);
+///
+/// // Send a message to the connected host
+/// std::string message = "Hi, I am a client";
+/// socket.send(message.c_str(), message.size() + 1);
+///
+/// // Receive an answer from the server
+/// char buffer[1024];
+/// std::size_t received = 0;
+/// socket.receive(buffer, sizeof(buffer), received);
+/// std::cout << "The server said: " << buffer << std::endl;
+///
+/// // ----- The server -----
+///
+/// // Create a listener to wait for incoming connections on port 55001
+/// sf::TcpListener listener;
+/// listener.listen(55001);
+///
+/// // Wait for a connection
+/// sf::TcpSocket socket;
+/// listener.accept(socket);
+/// std::cout << "New client connected: " << socket.getRemoteAddress() << std::endl;
+///
+/// // Receive a message from the client
+/// char buffer[1024];
+/// std::size_t received = 0;
+/// socket.receive(buffer, sizeof(buffer), received);
+/// std::cout << "The client said: " << buffer << std::endl;
+///
+/// // Send an answer
+/// std::string message = "Welcome, client";
+/// socket.send(message.c_str(), message.size() + 1);
+/// \endcode
+///
+/// \see sf::Socket, sf::UdpSocket, sf::Packet
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Network/UdpSocket.hpp
+++ b/libs/include/SFML/Network/UdpSocket.hpp
@@ -1,0 +1,291 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_UDPSOCKET_HPP
+#define SFML_UDPSOCKET_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Network/Export.hpp>
+#include <SFML/Network/Socket.hpp>
+#include <SFML/Network/IpAddress.hpp>
+#include <vector>
+
+
+namespace sf
+{
+class Packet;
+
+////////////////////////////////////////////////////////////
+/// \brief Specialized socket using the UDP protocol
+///
+////////////////////////////////////////////////////////////
+class SFML_NETWORK_API UdpSocket : public Socket
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    // Constants
+    ////////////////////////////////////////////////////////////
+    enum
+    {
+        MaxDatagramSize = 65507 ///< The maximum number of bytes that can be sent in a single UDP datagram
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    UdpSocket();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the port to which the socket is bound locally
+    ///
+    /// If the socket is not bound to a port, this function
+    /// returns 0.
+    ///
+    /// \return Port to which the socket is bound
+    ///
+    /// \see bind
+    ///
+    ////////////////////////////////////////////////////////////
+    unsigned short getLocalPort() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Bind the socket to a specific port
+    ///
+    /// Binding the socket to a port is necessary for being
+    /// able to receive data on that port.
+    /// You can use the special value Socket::AnyPort to tell the
+    /// system to automatically pick an available port, and then
+    /// call getLocalPort to retrieve the chosen port.
+    ///
+    /// Since the socket can only be bound to a single port at
+    /// any given moment, if it is already bound when this
+    /// function is called, it will be unbound from the previous
+    /// port before being bound to the new one.
+    ///
+    /// \param port    Port to bind the socket to
+    /// \param address Address of the interface to bind to
+    ///
+    /// \return Status code
+    ///
+    /// \see unbind, getLocalPort
+    ///
+    ////////////////////////////////////////////////////////////
+    Status bind(unsigned short port, const IpAddress& address = IpAddress::Any);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Unbind the socket from the local port to which it is bound
+    ///
+    /// The port that the socket was previously bound to is immediately
+    /// made available to the operating system after this function is called.
+    /// This means that a subsequent call to bind() will be able to re-bind
+    /// the port if no other process has done so in the mean time.
+    /// If the socket is not bound to a port, this function has no effect.
+    ///
+    /// \see bind
+    ///
+    ////////////////////////////////////////////////////////////
+    void unbind();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Send raw data to a remote peer
+    ///
+    /// Make sure that \a size is not greater than
+    /// UdpSocket::MaxDatagramSize, otherwise this function will
+    /// fail and no data will be sent.
+    ///
+    /// \param data          Pointer to the sequence of bytes to send
+    /// \param size          Number of bytes to send
+    /// \param remoteAddress Address of the receiver
+    /// \param remotePort    Port of the receiver to send the data to
+    ///
+    /// \return Status code
+    ///
+    /// \see receive
+    ///
+    ////////////////////////////////////////////////////////////
+    Status send(const void* data, std::size_t size, const IpAddress& remoteAddress, unsigned short remotePort);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Receive raw data from a remote peer
+    ///
+    /// In blocking mode, this function will wait until some
+    /// bytes are actually received.
+    /// Be careful to use a buffer which is large enough for
+    /// the data that you intend to receive, if it is too small
+    /// then an error will be returned and *all* the data will
+    /// be lost.
+    ///
+    /// \param data          Pointer to the array to fill with the received bytes
+    /// \param size          Maximum number of bytes that can be received
+    /// \param received      This variable is filled with the actual number of bytes received
+    /// \param remoteAddress Address of the peer that sent the data
+    /// \param remotePort    Port of the peer that sent the data
+    ///
+    /// \return Status code
+    ///
+    /// \see send
+    ///
+    ////////////////////////////////////////////////////////////
+    Status receive(void* data, std::size_t size, std::size_t& received, IpAddress& remoteAddress, unsigned short& remotePort);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Send a formatted packet of data to a remote peer
+    ///
+    /// Make sure that the packet size is not greater than
+    /// UdpSocket::MaxDatagramSize, otherwise this function will
+    /// fail and no data will be sent.
+    ///
+    /// \param packet        Packet to send
+    /// \param remoteAddress Address of the receiver
+    /// \param remotePort    Port of the receiver to send the data to
+    ///
+    /// \return Status code
+    ///
+    /// \see receive
+    ///
+    ////////////////////////////////////////////////////////////
+    Status send(Packet& packet, const IpAddress& remoteAddress, unsigned short remotePort);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Receive a formatted packet of data from a remote peer
+    ///
+    /// In blocking mode, this function will wait until the whole packet
+    /// has been received.
+    ///
+    /// \param packet        Packet to fill with the received data
+    /// \param remoteAddress Address of the peer that sent the data
+    /// \param remotePort    Port of the peer that sent the data
+    ///
+    /// \return Status code
+    ///
+    /// \see send
+    ///
+    ////////////////////////////////////////////////////////////
+    Status receive(Packet& packet, IpAddress& remoteAddress, unsigned short& remotePort);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::vector<char> m_buffer; ///< Temporary buffer holding the received data in Receive(Packet)
+};
+
+} // namespace sf
+
+
+#endif // SFML_UDPSOCKET_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::UdpSocket
+/// \ingroup network
+///
+/// A UDP socket is a connectionless socket. Instead of
+/// connecting once to a remote host, like TCP sockets,
+/// it can send to and receive from any host at any time.
+///
+/// It is a datagram protocol: bounded blocks of data (datagrams)
+/// are transfered over the network rather than a continuous
+/// stream of data (TCP). Therefore, one call to send will always
+/// match one call to receive (if the datagram is not lost),
+/// with the same data that was sent.
+///
+/// The UDP protocol is lightweight but unreliable. Unreliable
+/// means that datagrams may be duplicated, be lost or
+/// arrive reordered. However, if a datagram arrives, its
+/// data is guaranteed to be valid.
+///
+/// UDP is generally used for real-time communication
+/// (audio or video streaming, real-time games, etc.) where
+/// speed is crucial and lost data doesn't matter much.
+///
+/// Sending and receiving data can use either the low-level
+/// or the high-level functions. The low-level functions
+/// process a raw sequence of bytes, whereas the high-level
+/// interface uses packets (see sf::Packet), which are easier
+/// to use and provide more safety regarding the data that is
+/// exchanged. You can look at the sf::Packet class to get
+/// more details about how they work.
+///
+/// It is important to note that UdpSocket is unable to send
+/// datagrams bigger than MaxDatagramSize. In this case, it
+/// returns an error and doesn't send anything. This applies
+/// to both raw data and packets. Indeed, even packets are
+/// unable to split and recompose data, due to the unreliability
+/// of the protocol (dropped, mixed or duplicated datagrams may
+/// lead to a big mess when trying to recompose a packet).
+///
+/// If the socket is bound to a port, it is automatically
+/// unbound from it when the socket is destroyed. However,
+/// you can unbind the socket explicitly with the Unbind
+/// function if necessary, to stop receiving messages or
+/// make the port available for other sockets.
+///
+/// Usage example:
+/// \code
+/// // ----- The client -----
+///
+/// // Create a socket and bind it to the port 55001
+/// sf::UdpSocket socket;
+/// socket.bind(55001);
+///
+/// // Send a message to 192.168.1.50 on port 55002
+/// std::string message = "Hi, I am " + sf::IpAddress::getLocalAddress().toString();
+/// socket.send(message.c_str(), message.size() + 1, "192.168.1.50", 55002);
+///
+/// // Receive an answer (most likely from 192.168.1.50, but could be anyone else)
+/// char buffer[1024];
+/// std::size_t received = 0;
+/// sf::IpAddress sender;
+/// unsigned short port;
+/// socket.receive(buffer, sizeof(buffer), received, sender, port);
+/// std::cout << sender.ToString() << " said: " << buffer << std::endl;
+///
+/// // ----- The server -----
+///
+/// // Create a socket and bind it to the port 55002
+/// sf::UdpSocket socket;
+/// socket.bind(55002);
+///
+/// // Receive a message from anyone
+/// char buffer[1024];
+/// std::size_t received = 0;
+/// sf::IpAddress sender;
+/// unsigned short port;
+/// socket.receive(buffer, sizeof(buffer), received, sender, port);
+/// std::cout << sender.ToString() << " said: " << buffer << std::endl;
+///
+/// // Send an answer
+/// std::string message = "Welcome " + sender.toString();
+/// socket.send(message.c_str(), message.size() + 1, sender, port);
+/// \endcode
+///
+/// \see sf::Socket, sf::TcpSocket, sf::Packet
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/OpenGL.hpp
+++ b/libs/include/SFML/OpenGL.hpp
@@ -1,0 +1,78 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_OPENGL_HPP
+#define SFML_OPENGL_HPP
+
+
+////////////////////////////////////////////////////////////
+/// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+////////////////////////////////////////////////////////////
+/// This file just includes the OpenGL headers,
+/// which have actually different paths on each system
+////////////////////////////////////////////////////////////
+#if defined(SFML_SYSTEM_WINDOWS)
+
+    // The Visual C++ version of gl.h uses WINGDIAPI and APIENTRY but doesn't define them
+    #ifdef _MSC_VER
+        #include <windows.h>
+    #endif
+
+    #include <GL/gl.h>
+
+#elif defined(SFML_SYSTEM_LINUX) || defined(SFML_SYSTEM_FREEBSD) || defined(SFML_SYSTEM_OPENBSD)
+
+    #if defined(SFML_OPENGL_ES)
+        #include <GLES/gl.h>
+        #include <GLES/glext.h>
+    #else
+        #include <GL/gl.h>
+    #endif
+
+#elif defined(SFML_SYSTEM_MACOS)
+
+    #include <OpenGL/gl.h>
+
+#elif defined (SFML_SYSTEM_IOS)
+
+    #include <OpenGLES/ES1/gl.h>
+    #include <OpenGLES/ES1/glext.h>
+
+#elif defined (SFML_SYSTEM_ANDROID)
+
+    #include <GLES/gl.h>
+    #include <GLES/glext.h>
+    
+    // We're not using OpenGL ES 2+ yet, but we can use the sRGB extension
+    #include <GLES2/gl2platform.h>
+    #include <GLES2/gl2ext.h>
+
+#endif
+
+
+#endif // SFML_OPENGL_HPP

--- a/libs/include/SFML/System.hpp
+++ b/libs/include/SFML/System.hpp
@@ -1,0 +1,60 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SYSTEM_HPP
+#define SFML_SYSTEM_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
+#include <SFML/Config.hpp>
+#include <SFML/System/Clock.hpp>
+#include <SFML/System/Err.hpp>
+#include <SFML/System/FileInputStream.hpp>
+#include <SFML/System/InputStream.hpp>
+#include <SFML/System/Lock.hpp>
+#include <SFML/System/MemoryInputStream.hpp>
+#include <SFML/System/Mutex.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/Sleep.hpp>
+#include <SFML/System/String.hpp>
+#include <SFML/System/Thread.hpp>
+#include <SFML/System/ThreadLocal.hpp>
+#include <SFML/System/ThreadLocalPtr.hpp>
+#include <SFML/System/Time.hpp>
+#include <SFML/System/Utf.hpp>
+#include <SFML/System/Vector2.hpp>
+#include <SFML/System/Vector3.hpp>
+
+#endif // SFML_SYSTEM_HPP
+
+////////////////////////////////////////////////////////////
+/// \defgroup system System module
+///
+/// Base module of SFML, defining various utilities. It provides
+/// vector classes, Unicode strings and conversion functions,
+/// threads and mutexes, timing classes.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Clock.hpp
+++ b/libs/include/SFML/System/Clock.hpp
@@ -1,0 +1,117 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CLOCK_HPP
+#define SFML_CLOCK_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+#include <SFML/System/Time.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Utility class that measures the elapsed time
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API Clock
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// The clock starts automatically after being constructed.
+    ///
+    ////////////////////////////////////////////////////////////
+    Clock();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the elapsed time
+    ///
+    /// This function returns the time elapsed since the last call
+    /// to restart() (or the construction of the instance if restart()
+    /// has not been called).
+    ///
+    /// \return Time elapsed
+    ///
+    ////////////////////////////////////////////////////////////
+    Time getElapsedTime() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Restart the clock
+    ///
+    /// This function puts the time counter back to zero.
+    /// It also returns the time elapsed since the clock was started.
+    ///
+    /// \return Time elapsed
+    ///
+    ////////////////////////////////////////////////////////////
+    Time restart();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Time m_startTime; ///< Time of last reset, in microseconds
+};
+
+} // namespace sf
+
+
+#endif // SFML_CLOCK_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Clock
+/// \ingroup system
+///
+/// sf::Clock is a lightweight class for measuring time.
+///
+/// Its provides the most precise time that the underlying
+/// OS can achieve (generally microseconds or nanoseconds).
+/// It also ensures monotonicity, which means that the returned
+/// time can never go backward, even if the system time is
+/// changed.
+///
+/// Usage example:
+/// \code
+/// sf::Clock clock;
+/// ...
+/// Time time1 = clock.getElapsedTime();
+/// ...
+/// Time time2 = clock.restart();
+/// \endcode
+///
+/// The sf::Time value returned by the clock can then be
+/// converted to a number of seconds, milliseconds or even
+/// microseconds.
+///
+/// \see sf::Time
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Err.hpp
+++ b/libs/include/SFML/System/Err.hpp
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_ERR_HPP
+#define SFML_ERR_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+#include <ostream>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Standard stream used by SFML to output warnings and errors
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API std::ostream& err();
+
+} // namespace sf
+
+
+#endif // SFML_ERR_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \fn sf::err
+/// \ingroup system
+///
+/// By default, sf::err() outputs to the same location as std::cerr,
+/// (-> the stderr descriptor) which is the console if there's
+/// one available.
+///
+/// It is a standard std::ostream instance, so it supports all the
+/// insertion operations defined by the STL
+/// (operator <<, manipulators, etc.).
+///
+/// sf::err() can be redirected to write to another output, independently
+/// of std::cerr, by using the rdbuf() function provided by the
+/// std::ostream class.
+///
+/// Example:
+/// \code
+/// // Redirect to a file
+/// std::ofstream file("sfml-log.txt");
+/// std::streambuf* previous = sf::err().rdbuf(file.rdbuf());
+///
+/// // Redirect to nothing
+/// sf::err().rdbuf(NULL);
+///
+/// // Restore the original output
+/// sf::err().rdbuf(previous);
+/// \endcode
+///
+/// \return Reference to std::ostream representing the SFML error stream
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Export.hpp
+++ b/libs/include/SFML/System/Export.hpp
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SYSTEM_EXPORT_HPP
+#define SFML_SYSTEM_EXPORT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+////////////////////////////////////////////////////////////
+// Define portable import / export macros
+////////////////////////////////////////////////////////////
+#if defined(SFML_SYSTEM_EXPORTS)
+
+    #define SFML_SYSTEM_API SFML_API_EXPORT
+
+#else
+
+    #define SFML_SYSTEM_API SFML_API_IMPORT
+
+#endif
+
+
+#endif // SFML_SYSTEM_EXPORT_HPP

--- a/libs/include/SFML/System/FileInputStream.hpp
+++ b/libs/include/SFML/System/FileInputStream.hpp
@@ -1,0 +1,169 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_FILEINPUTSTREAM_HPP
+#define SFML_FILEINPUTSTREAM_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+#include <SFML/System/Export.hpp>
+#include <SFML/System/InputStream.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <cstdio>
+#include <string>
+
+#ifdef SFML_SYSTEM_ANDROID
+namespace sf
+{
+namespace priv
+{
+class SFML_SYSTEM_API ResourceStream;
+}
+}
+#endif
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Implementation of input stream based on a file
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API FileInputStream : public InputStream, NonCopyable
+{
+public:
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    FileInputStream();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~FileInputStream();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open the stream from a file path
+    ///
+    /// \param filename Name of the file to open
+    ///
+    /// \return True on success, false on error
+    ///
+    ////////////////////////////////////////////////////////////
+    bool open(const std::string& filename);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Read data from the stream
+    ///
+    /// After reading, the stream's reading position must be
+    /// advanced by the amount of bytes read.
+    ///
+    /// \param data Buffer where to copy the read data
+    /// \param size Desired number of bytes to read
+    ///
+    /// \return The number of bytes actually read, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 read(void* data, Int64 size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current reading position
+    ///
+    /// \param position The position to seek to, from the beginning
+    ///
+    /// \return The position actually sought to, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 seek(Int64 position);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current reading position in the stream
+    ///
+    /// \return The current position, or -1 on error.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 tell();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the size of the stream
+    ///
+    /// \return The total number of bytes available in the stream, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 getSize();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+#ifdef SFML_SYSTEM_ANDROID
+    priv::ResourceStream* m_file;
+#else
+    std::FILE* m_file; ///< stdio file stream
+#endif
+};
+
+} // namespace sf
+
+
+#endif // SFML_FILEINPUTSTREAM_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::FileInputStream
+/// \ingroup system
+///
+/// This class is a specialization of InputStream that
+/// reads from a file on disk.
+///
+/// It wraps a file in the common InputStream interface
+/// and therefore allows to use generic classes or functions
+/// that accept such a stream, with a file on disk as the data
+/// source.
+///
+/// In addition to the virtual functions inherited from
+/// InputStream, FileInputStream adds a function to
+/// specify the file to open.
+///
+/// SFML resource classes can usually be loaded directly from
+/// a filename, so this class shouldn't be useful to you unless
+/// you create your own algorithms that operate on an InputStream.
+///
+/// Usage example:
+/// \code
+/// void process(InputStream& stream);
+///
+/// FileInputStream stream;
+/// if (stream.open("some_file.dat"))
+///    process(stream);
+/// \endcode
+///
+/// InputStream, MemoryInputStream
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/InputStream.hpp
+++ b/libs/include/SFML/System/InputStream.hpp
@@ -1,0 +1,152 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_INPUTSTREAM_HPP
+#define SFML_INPUTSTREAM_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+#include <SFML/System/Export.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Abstract class for custom file input streams
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API InputStream
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Virtual destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~InputStream() {}
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Read data from the stream
+    ///
+    /// After reading, the stream's reading position must be
+    /// advanced by the amount of bytes read.
+    ///
+    /// \param data Buffer where to copy the read data
+    /// \param size Desired number of bytes to read
+    ///
+    /// \return The number of bytes actually read, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 read(void* data, Int64 size) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current reading position
+    ///
+    /// \param position The position to seek to, from the beginning
+    ///
+    /// \return The position actually sought to, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 seek(Int64 position) = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current reading position in the stream
+    ///
+    /// \return The current position, or -1 on error.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 tell() = 0;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the size of the stream
+    ///
+    /// \return The total number of bytes available in the stream, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 getSize() = 0;
+};
+
+} // namespace sf
+
+
+#endif // SFML_INPUTSTREAM_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::InputStream
+/// \ingroup system
+///
+/// This class allows users to define their own file input sources
+/// from which SFML can load resources.
+///
+/// SFML resource classes like sf::Texture and
+/// sf::SoundBuffer provide loadFromFile and loadFromMemory functions,
+/// which read data from conventional sources. However, if you
+/// have data coming from a different source (over a network,
+/// embedded, encrypted, compressed, etc) you can derive your
+/// own class from sf::InputStream and load SFML resources with
+/// their loadFromStream function.
+///
+/// Usage example:
+/// \code
+/// // custom stream class that reads from inside a zip file
+/// class ZipStream : public sf::InputStream
+/// {
+/// public:
+///
+///     ZipStream(std::string archive);
+///
+///     bool open(std::string filename);
+///
+///     Int64 read(void* data, Int64 size);
+///
+///     Int64 seek(Int64 position);
+///
+///     Int64 tell();
+///
+///     Int64 getSize();
+///
+/// private:
+///
+///     ...
+/// };
+///
+/// // now you can load textures...
+/// sf::Texture texture;
+/// ZipStream stream("resources.zip");
+/// stream.open("images/img.png");
+/// texture.loadFromStream(stream);
+///
+/// // musics...
+/// sf::Music music;
+/// ZipStream stream("resources.zip");
+/// stream.open("musics/msc.ogg");
+/// music.openFromStream(stream);
+///
+/// // etc.
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Lock.hpp
+++ b/libs/include/SFML/System/Lock.hpp
@@ -1,0 +1,139 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_LOCK_HPP
+#define SFML_LOCK_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
+
+
+namespace sf
+{
+class Mutex;
+
+////////////////////////////////////////////////////////////
+/// \brief Automatic wrapper for locking and unlocking mutexes
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API Lock : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the lock with a target mutex
+    ///
+    /// The mutex passed to sf::Lock is automatically locked.
+    ///
+    /// \param mutex Mutex to lock
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Lock(Mutex& mutex);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// The destructor of sf::Lock automatically unlocks its mutex.
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Lock();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Mutex& m_mutex; ///< Mutex to lock / unlock
+};
+
+} // namespace sf
+
+
+#endif // SFML_LOCK_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Lock
+/// \ingroup system
+///
+/// sf::Lock is a RAII wrapper for sf::Mutex. By unlocking
+/// it in its destructor, it ensures that the mutex will
+/// always be released when the current scope (most likely
+/// a function) ends.
+/// This is even more important when an exception or an early
+/// return statement can interrupt the execution flow of the
+/// function.
+///
+/// For maximum robustness, sf::Lock should always be used
+/// to lock/unlock a mutex.
+///
+/// Usage example:
+/// \code
+/// sf::Mutex mutex;
+///
+/// void function()
+/// {
+///     sf::Lock lock(mutex); // mutex is now locked
+///
+///     functionThatMayThrowAnException(); // mutex is unlocked if this function throws
+///
+///     if (someCondition)
+///         return; // mutex is unlocked
+///
+/// } // mutex is unlocked
+/// \endcode
+///
+/// Because the mutex is not explicitly unlocked in the code,
+/// it may remain locked longer than needed. If the region
+/// of the code that needs to be protected by the mutex is
+/// not the entire function, a good practice is to create a
+/// smaller, inner scope so that the lock is limited to this
+/// part of the code.
+///
+/// \code
+/// sf::Mutex mutex;
+///
+/// void function()
+/// {
+///     {
+///       sf::Lock lock(mutex);
+///       codeThatRequiresProtection();
+///
+///     } // mutex is unlocked here
+///
+///     codeThatDoesntCareAboutTheMutex();
+/// }
+/// \endcode
+///
+/// Having a mutex locked longer than required is a bad practice
+/// which can lead to bad performances. Don't forget that when
+/// a mutex is locked, other threads may be waiting doing nothing
+/// until it is released.
+///
+/// \see sf::Mutex
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/MemoryInputStream.hpp
+++ b/libs/include/SFML/System/MemoryInputStream.hpp
@@ -1,0 +1,148 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_MEMORYINPUTSTREAM_HPP
+#define SFML_MEMORYINPUTSTREAM_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+#include <SFML/System/InputStream.hpp>
+#include <SFML/System/Export.hpp>
+#include <cstdlib>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Implementation of input stream based on a memory chunk
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API MemoryInputStream : public InputStream
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    MemoryInputStream();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Open the stream from its data
+    ///
+    /// \param data        Pointer to the data in memory
+    /// \param sizeInBytes Size of the data, in bytes
+    ///
+    ////////////////////////////////////////////////////////////
+    void open(const void* data, std::size_t sizeInBytes);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Read data from the stream
+    ///
+    /// After reading, the stream's reading position must be
+    /// advanced by the amount of bytes read.
+    ///
+    /// \param data Buffer where to copy the read data
+    /// \param size Desired number of bytes to read
+    ///
+    /// \return The number of bytes actually read, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 read(void* data, Int64 size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the current reading position
+    ///
+    /// \param position The position to seek to, from the beginning
+    ///
+    /// \return The position actually sought to, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 seek(Int64 position);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current reading position in the stream
+    ///
+    /// \return The current position, or -1 on error.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 tell();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the size of the stream
+    ///
+    /// \return The total number of bytes available in the stream, or -1 on error
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual Int64 getSize();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    const char* m_data;   ///< Pointer to the data in memory
+    Int64       m_size;   ///< Total size of the data
+    Int64       m_offset; ///< Current reading position
+};
+
+} // namespace sf
+
+
+#endif // SFML_MEMORYINPUTSTREAM_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::MemoryInputStream
+/// \ingroup system
+///
+/// This class is a specialization of InputStream that
+/// reads from data in memory.
+///
+/// It wraps a memory chunk in the common InputStream interface
+/// and therefore allows to use generic classes or functions
+/// that accept such a stream, with content already loaded in memory.
+///
+/// In addition to the virtual functions inherited from
+/// InputStream, MemoryInputStream adds a function to
+/// specify the pointer and size of the data in memory.
+///
+/// SFML resource classes can usually be loaded directly from
+/// memory, so this class shouldn't be useful to you unless
+/// you create your own algorithms that operate on an InputStream.
+///
+/// Usage example:
+/// \code
+/// void process(InputStream& stream);
+///
+/// MemoryInputStream stream;
+/// stream.open(thePtr, theSize);
+/// process(stream);
+/// \endcode
+///
+/// InputStream, FileInputStream
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Mutex.hpp
+++ b/libs/include/SFML/System/Mutex.hpp
@@ -1,0 +1,148 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_MUTEX_HPP
+#define SFML_MUTEX_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
+
+
+namespace sf
+{
+namespace priv
+{
+    class MutexImpl;
+}
+
+////////////////////////////////////////////////////////////
+/// \brief Blocks concurrent access to shared resources
+///        from multiple threads
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API Mutex : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    Mutex();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Mutex();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Lock the mutex
+    ///
+    /// If the mutex is already locked in another thread,
+    /// this call will block the execution until the mutex
+    /// is released.
+    ///
+    /// \see unlock
+    ///
+    ////////////////////////////////////////////////////////////
+    void lock();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Unlock the mutex
+    ///
+    /// \see lock
+    ///
+    ////////////////////////////////////////////////////////////
+    void unlock();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    priv::MutexImpl* m_mutexImpl; ///< OS-specific implementation
+};
+
+} // namespace sf
+
+
+#endif // SFML_MUTEX_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Mutex
+/// \ingroup system
+///
+/// Mutex stands for "MUTual EXclusion". A mutex is a
+/// synchronization object, used when multiple threads are involved.
+///
+/// When you want to protect a part of the code from being accessed
+/// simultaneously by multiple threads, you typically use a
+/// mutex. When a thread is locked by a mutex, any other thread
+/// trying to lock it will be blocked until the mutex is released
+/// by the thread that locked it. This way, you can allow only
+/// one thread at a time to access a critical region of your code.
+///
+/// Usage example:
+/// \code
+/// Database database; // this is a critical resource that needs some protection
+/// sf::Mutex mutex;
+///
+/// void thread1()
+/// {
+///     mutex.lock(); // this call will block the thread if the mutex is already locked by thread2
+///     database.write(...);
+///     mutex.unlock(); // if thread2 was waiting, it will now be unblocked
+/// }
+///
+/// void thread2()
+/// {
+///     mutex.lock(); // this call will block the thread if the mutex is already locked by thread1
+///     database.write(...);
+///     mutex.unlock(); // if thread1 was waiting, it will now be unblocked
+/// }
+/// \endcode
+///
+/// Be very careful with mutexes. A bad usage can lead to bad problems,
+/// like deadlocks (two threads are waiting for each other and the
+/// application is globally stuck).
+///
+/// To make the usage of mutexes more robust, particularly in
+/// environments where exceptions can be thrown, you should
+/// use the helper class sf::Lock to lock/unlock mutexes.
+///
+/// SFML mutexes are recursive, which means that you can lock
+/// a mutex multiple times in the same thread without creating
+/// a deadlock. In this case, the first call to lock() behaves
+/// as usual, and the following ones have no effect.
+/// However, you must call unlock() exactly as many times as you
+/// called lock(). If you don't, the mutex won't be released.
+///
+/// \see sf::Lock
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/NativeActivity.hpp
+++ b/libs/include/SFML/System/NativeActivity.hpp
@@ -1,0 +1,62 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_NATIVEACTIVITY_HPP
+#define SFML_NATIVEACTIVITY_HPP
+
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+
+
+#if !defined(SFML_SYSTEM_ANDROID)
+#error NativeActivity.hpp: This header is Android only.
+#endif
+
+
+struct ANativeActivity;
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \ingroup system
+/// \brief Return a pointer to the Android native activity
+///
+/// You shouldn't have to use this function, unless you want
+/// to implement very specific details, that SFML doesn't
+/// support, or to use a workaround for a known issue.
+///
+/// \return Pointer to Android native activity structure
+///
+/// \sfplatform{Android,SFML/System/NativeActivity.hpp}
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API ANativeActivity* getNativeActivity();
+
+} // namespace sf
+
+
+#endif // SFML_NATIVEACTIVITY_HPP

--- a/libs/include/SFML/System/NonCopyable.hpp
+++ b/libs/include/SFML/System/NonCopyable.hpp
@@ -1,0 +1,129 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_NONCOPYABLE_HPP
+#define SFML_NONCOPYABLE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Utility class that makes any derived
+///        class non-copyable
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API NonCopyable
+{
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Because this class has a copy constructor, the compiler
+    /// will not automatically generate the default constructor.
+    /// That's why we must define it explicitly.
+    ///
+    ////////////////////////////////////////////////////////////
+    NonCopyable() {}
+    
+    ////////////////////////////////////////////////////////////
+    /// \brief Default destructor
+    ///
+    /// By declaring a protected destructor it's impossible to
+    /// call delete on a pointer of sf::NonCopyable, thus
+    /// preventing possible resource leaks.
+    ///
+    ////////////////////////////////////////////////////////////
+    ~NonCopyable() {}
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Disabled copy constructor
+    ///
+    /// By making the copy constructor private, the compiler will
+    /// trigger an error if anyone outside tries to use it.
+    /// To prevent NonCopyable or friend classes from using it,
+    /// we also give no definition, so that the linker will
+    /// produce an error if the first protection was inefficient.
+    ///
+    ////////////////////////////////////////////////////////////
+    NonCopyable(const NonCopyable&);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Disabled assignment operator
+    ///
+    /// By making the assignment operator private, the compiler will
+    /// trigger an error if anyone outside tries to use it.
+    /// To prevent NonCopyable or friend classes from using it,
+    /// we also give no definition, so that the linker will
+    /// produce an error if the first protection was inefficient.
+    ///
+    ////////////////////////////////////////////////////////////
+    NonCopyable& operator =(const NonCopyable&);
+};
+
+} // namespace sf
+
+
+#endif // SFML_NONCOPYABLE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::NonCopyable
+/// \ingroup system
+///
+/// This class makes its instances non-copyable, by explicitly
+/// disabling its copy constructor and its assignment operator.
+///
+/// To create a non-copyable class, simply inherit from
+/// sf::NonCopyable.
+///
+/// The type of inheritance (public or private) doesn't matter,
+/// the copy constructor and assignment operator are declared private
+/// in sf::NonCopyable so they will end up being inaccessible in both
+/// cases. Thus you can use a shorter syntax for inheriting from it
+/// (see below).
+///
+/// Usage example:
+/// \code
+/// class MyNonCopyableClass : sf::NonCopyable
+/// {
+///     ...
+/// };
+/// \endcode
+///
+/// Deciding whether the instances of a class can be copied
+/// or not is a very important design choice. You are strongly
+/// encouraged to think about it before writing a class,
+/// and to use sf::NonCopyable when necessary to prevent
+/// many potential future errors when using it. This is also
+/// a very important indication to users of your class.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Sleep.hpp
+++ b/libs/include/SFML/System/Sleep.hpp
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SLEEP_HPP
+#define SFML_SLEEP_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+#include <SFML/System/Time.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \ingroup system
+/// \brief Make the current thread sleep for a given duration
+///
+/// sf::sleep is the best way to block a program or one of its
+/// threads, as it doesn't consume any CPU power.
+///
+/// \param duration Time to sleep
+///
+////////////////////////////////////////////////////////////
+void SFML_SYSTEM_API sleep(Time duration);
+
+} // namespace sf
+
+
+#endif // SFML_SLEEP_HPP

--- a/libs/include/SFML/System/String.hpp
+++ b/libs/include/SFML/System/String.hpp
@@ -1,0 +1,669 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_STRING_HPP
+#define SFML_STRING_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+#include <SFML/System/Utf.hpp>
+#include <iterator>
+#include <locale>
+#include <string>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Utility string class that automatically handles
+///        conversions between types and encodings
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API String
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    // Types
+    ////////////////////////////////////////////////////////////
+    typedef std::basic_string<Uint32>::iterator       Iterator;      ///< Iterator type
+    typedef std::basic_string<Uint32>::const_iterator ConstIterator; ///< Read-only iterator type
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static const std::size_t InvalidPos; ///< Represents an invalid position in the string
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor creates an empty string.
+    ///
+    ////////////////////////////////////////////////////////////
+    String();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from a single ANSI character and a locale
+    ///
+    /// The source character is converted to UTF-32 according
+    /// to the given locale.
+    ///
+    /// \param ansiChar ANSI character to convert
+    /// \param locale   Locale to use for conversion
+    ///
+    ////////////////////////////////////////////////////////////
+    String(char ansiChar, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from single wide character
+    ///
+    /// \param wideChar Wide character to convert
+    ///
+    ////////////////////////////////////////////////////////////
+    String(wchar_t wideChar);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from single UTF-32 character
+    ///
+    /// \param utf32Char UTF-32 character to convert
+    ///
+    ////////////////////////////////////////////////////////////
+    String(Uint32 utf32Char);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from a null-terminated C-style ANSI string and a locale
+    ///
+    /// The source string is converted to UTF-32 according
+    /// to the given locale.
+    ///
+    /// \param ansiString ANSI string to convert
+    /// \param locale     Locale to use for conversion
+    ///
+    ////////////////////////////////////////////////////////////
+    String(const char* ansiString, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from an ANSI string and a locale
+    ///
+    /// The source string is converted to UTF-32 according
+    /// to the given locale.
+    ///
+    /// \param ansiString ANSI string to convert
+    /// \param locale     Locale to use for conversion
+    ///
+    ////////////////////////////////////////////////////////////
+    String(const std::string& ansiString, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from null-terminated C-style wide string
+    ///
+    /// \param wideString Wide string to convert
+    ///
+    ////////////////////////////////////////////////////////////
+    String(const wchar_t* wideString);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from a wide string
+    ///
+    /// \param wideString Wide string to convert
+    ///
+    ////////////////////////////////////////////////////////////
+    String(const std::wstring& wideString);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from a null-terminated C-style UTF-32 string
+    ///
+    /// \param utf32String UTF-32 string to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    String(const Uint32* utf32String);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from an UTF-32 string
+    ///
+    /// \param utf32String UTF-32 string to assign
+    ///
+    ////////////////////////////////////////////////////////////
+    String(const std::basic_string<Uint32>& utf32String);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Copy constructor
+    ///
+    /// \param copy Instance to copy
+    ///
+    ////////////////////////////////////////////////////////////
+    String(const String& copy);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a new sf::String from a UTF-8 encoded string
+    ///
+    /// \param begin Forward iterator to the beginning of the UTF-8 sequence
+    /// \param end   Forward iterator to the end of the UTF-8 sequence
+    ///
+    /// \return A sf::String containing the source string
+    ///
+    /// \see fromUtf16, fromUtf32
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    static String fromUtf8(T begin, T end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a new sf::String from a UTF-16 encoded string
+    ///
+    /// \param begin Forward iterator to the beginning of the UTF-16 sequence
+    /// \param end   Forward iterator to the end of the UTF-16 sequence
+    ///
+    /// \return A sf::String containing the source string
+    ///
+    /// \see fromUtf8, fromUtf32
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    static String fromUtf16(T begin, T end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a new sf::String from a UTF-32 encoded string
+    ///
+    /// This function is provided for consistency, it is equivalent to
+    /// using the constructors that takes a const sf::Uint32* or
+    /// a std::basic_string<sf::Uint32>.
+    ///
+    /// \param begin Forward iterator to the beginning of the UTF-32 sequence
+    /// \param end   Forward iterator to the end of the UTF-32 sequence
+    ///
+    /// \return A sf::String containing the source string
+    ///
+    /// \see fromUtf8, fromUtf16
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename T>
+    static String fromUtf32(T begin, T end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Implicit conversion operator to std::string (ANSI string)
+    ///
+    /// The current global locale is used for conversion. If you
+    /// want to explicitly specify a locale, see toAnsiString.
+    /// Characters that do not fit in the target encoding are
+    /// discarded from the returned string.
+    /// This operator is defined for convenience, and is equivalent
+    /// to calling toAnsiString().
+    ///
+    /// \return Converted ANSI string
+    ///
+    /// \see toAnsiString, operator std::wstring
+    ///
+    ////////////////////////////////////////////////////////////
+    operator std::string() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Implicit conversion operator to std::wstring (wide string)
+    ///
+    /// Characters that do not fit in the target encoding are
+    /// discarded from the returned string.
+    /// This operator is defined for convenience, and is equivalent
+    /// to calling toWideString().
+    ///
+    /// \return Converted wide string
+    ///
+    /// \see toWideString, operator std::string
+    ///
+    ////////////////////////////////////////////////////////////
+    operator std::wstring() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert the Unicode string to an ANSI string
+    ///
+    /// The UTF-32 string is converted to an ANSI string in
+    /// the encoding defined by \a locale.
+    /// Characters that do not fit in the target encoding are
+    /// discarded from the returned string.
+    ///
+    /// \param locale Locale to use for conversion
+    ///
+    /// \return Converted ANSI string
+    ///
+    /// \see toWideString, operator std::string
+    ///
+    ////////////////////////////////////////////////////////////
+    std::string toAnsiString(const std::locale& locale = std::locale()) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert the Unicode string to a wide string
+    ///
+    /// Characters that do not fit in the target encoding are
+    /// discarded from the returned string.
+    ///
+    /// \return Converted wide string
+    ///
+    /// \see toAnsiString, operator std::wstring
+    ///
+    ////////////////////////////////////////////////////////////
+    std::wstring toWideString() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert the Unicode string to a UTF-8 string
+    ///
+    /// \return Converted UTF-8 string
+    ///
+    /// \see toUtf16, toUtf32
+    ///
+    ////////////////////////////////////////////////////////////
+    std::basic_string<Uint8> toUtf8() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert the Unicode string to a UTF-16 string
+    ///
+    /// \return Converted UTF-16 string
+    ///
+    /// \see toUtf8, toUtf32
+    ///
+    ////////////////////////////////////////////////////////////
+    std::basic_string<Uint16> toUtf16() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert the Unicode string to a UTF-32 string
+    ///
+    /// This function doesn't perform any conversion, since the
+    /// string is already stored as UTF-32 internally.
+    ///
+    /// \return Converted UTF-32 string
+    ///
+    /// \see toUtf8, toUtf16
+    ///
+    ////////////////////////////////////////////////////////////
+    std::basic_string<Uint32> toUtf32() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of assignment operator
+    ///
+    /// \param right Instance to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    String& operator =(const String& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of += operator to append an UTF-32 string
+    ///
+    /// \param right String to append
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    String& operator +=(const String& right);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of [] operator to access a character by its position
+    ///
+    /// This function provides read-only access to characters.
+    /// Note: the behavior is undefined if \a index is out of range.
+    ///
+    /// \param index Index of the character to get
+    ///
+    /// \return Character at position \a index
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint32 operator [](std::size_t index) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of [] operator to access a character by its position
+    ///
+    /// This function provides read and write access to characters.
+    /// Note: the behavior is undefined if \a index is out of range.
+    ///
+    /// \param index Index of the character to get
+    ///
+    /// \return Reference to the character at position \a index
+    ///
+    ////////////////////////////////////////////////////////////
+    Uint32& operator [](std::size_t index);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Clear the string
+    ///
+    /// This function removes all the characters from the string.
+    ///
+    /// \see isEmpty, erase
+    ///
+    ////////////////////////////////////////////////////////////
+    void clear();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the size of the string
+    ///
+    /// \return Number of characters in the string
+    ///
+    /// \see isEmpty
+    ///
+    ////////////////////////////////////////////////////////////
+    std::size_t getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check whether the string is empty or not
+    ///
+    /// \return True if the string is empty (i.e. contains no character)
+    ///
+    /// \see clear, getSize
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isEmpty() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Erase one or more characters from the string
+    ///
+    /// This function removes a sequence of \a count characters
+    /// starting from \a position.
+    ///
+    /// \param position Position of the first character to erase
+    /// \param count    Number of characters to erase
+    ///
+    ////////////////////////////////////////////////////////////
+    void erase(std::size_t position, std::size_t count = 1);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Insert one or more characters into the string
+    ///
+    /// This function inserts the characters of \a str
+    /// into the string, starting from \a position.
+    ///
+    /// \param position Position of insertion
+    /// \param str      Characters to insert
+    ///
+    ////////////////////////////////////////////////////////////
+    void insert(std::size_t position, const String& str);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Find a sequence of one or more characters in the string
+    ///
+    /// This function searches for the characters of \a str
+    /// in the string, starting from \a start.
+    ///
+    /// \param str   Characters to find
+    /// \param start Where to begin searching
+    ///
+    /// \return Position of \a str in the string, or String::InvalidPos if not found
+    ///
+    ////////////////////////////////////////////////////////////
+    std::size_t find(const String& str, std::size_t start = 0) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Replace a substring with another string
+    ///
+    /// This function replaces the substring that starts at index \a position
+    /// and spans \a length characters with the string \a replaceWith.
+    ///
+    /// \param position    Index of the first character to be replaced
+    /// \param length      Number of characters to replace. You can pass InvalidPos to
+    ///                    replace all characters until the end of the string.
+    /// \param replaceWith String that replaces the given substring.
+    ///
+    ////////////////////////////////////////////////////////////
+    void replace(std::size_t position, std::size_t length, const String& replaceWith);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Replace all occurrences of a substring with a replacement string
+    ///
+    /// This function replaces all occurrences of \a searchFor in this string
+    /// with the string \a replaceWith.
+    ///
+    /// \param searchFor   The value being searched for
+    /// \param replaceWith The value that replaces found \a searchFor values
+    ///
+    ////////////////////////////////////////////////////////////
+    void replace(const String& searchFor, const String& replaceWith);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return a part of the string
+    ///
+    /// This function returns the substring that starts at index \a position
+    /// and spans \a length characters.
+    ///
+    /// \param position Index of the first character
+    /// \param length   Number of characters to include in the substring (if
+    ///                 the string is shorter, as many characters as possible
+    ///                 are included). \ref InvalidPos can be used to include all
+    ///                 characters until the end of the string.
+    ///
+    /// \return String object containing a substring of this object
+    ///
+    ////////////////////////////////////////////////////////////
+    String substring(std::size_t position, std::size_t length = InvalidPos) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get a pointer to the C-style array of characters
+    ///
+    /// This functions provides a read-only access to a
+    /// null-terminated C-style representation of the string.
+    /// The returned pointer is temporary and is meant only for
+    /// immediate use, thus it is not recommended to store it.
+    ///
+    /// \return Read-only pointer to the array of characters
+    ///
+    ////////////////////////////////////////////////////////////
+    const Uint32* getData() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return an iterator to the beginning of the string
+    ///
+    /// \return Read-write iterator to the beginning of the string characters
+    ///
+    /// \see end
+    ///
+    ////////////////////////////////////////////////////////////
+    Iterator begin();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return an iterator to the beginning of the string
+    ///
+    /// \return Read-only iterator to the beginning of the string characters
+    ///
+    /// \see end
+    ///
+    ////////////////////////////////////////////////////////////
+    ConstIterator begin() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return an iterator to the end of the string
+    ///
+    /// The end iterator refers to 1 position past the last character;
+    /// thus it represents an invalid character and should never be
+    /// accessed.
+    ///
+    /// \return Read-write iterator to the end of the string characters
+    ///
+    /// \see begin
+    ///
+    ////////////////////////////////////////////////////////////
+    Iterator end();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return an iterator to the end of the string
+    ///
+    /// The end iterator refers to 1 position past the last character;
+    /// thus it represents an invalid character and should never be
+    /// accessed.
+    ///
+    /// \return Read-only iterator to the end of the string characters
+    ///
+    /// \see begin
+    ///
+    ////////////////////////////////////////////////////////////
+    ConstIterator end() const;
+
+private:
+
+    friend SFML_SYSTEM_API bool operator ==(const String& left, const String& right);
+    friend SFML_SYSTEM_API bool operator <(const String& left, const String& right);
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    std::basic_string<Uint32> m_string; ///< Internal string of UTF-32 characters
+};
+
+////////////////////////////////////////////////////////////
+/// \relates String
+/// \brief Overload of == operator to compare two UTF-32 strings
+///
+/// \param left  Left operand (a string)
+/// \param right Right operand (a string)
+///
+/// \return True if both strings are equal
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator ==(const String& left, const String& right);
+
+////////////////////////////////////////////////////////////
+/// \relates String
+/// \brief Overload of != operator to compare two UTF-32 strings
+///
+/// \param left  Left operand (a string)
+/// \param right Right operand (a string)
+///
+/// \return True if both strings are different
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator !=(const String& left, const String& right);
+
+////////////////////////////////////////////////////////////
+/// \relates String
+/// \brief Overload of < operator to compare two UTF-32 strings
+///
+/// \param left  Left operand (a string)
+/// \param right Right operand (a string)
+///
+/// \return True if \a left is lexicographically before \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator <(const String& left, const String& right);
+
+////////////////////////////////////////////////////////////
+/// \relates String
+/// \brief Overload of > operator to compare two UTF-32 strings
+///
+/// \param left  Left operand (a string)
+/// \param right Right operand (a string)
+///
+/// \return True if \a left is lexicographically after \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator >(const String& left, const String& right);
+
+////////////////////////////////////////////////////////////
+/// \relates String
+/// \brief Overload of <= operator to compare two UTF-32 strings
+///
+/// \param left  Left operand (a string)
+/// \param right Right operand (a string)
+///
+/// \return True if \a left is lexicographically before or equivalent to \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator <=(const String& left, const String& right);
+
+////////////////////////////////////////////////////////////
+/// \relates String
+/// \brief Overload of >= operator to compare two UTF-32 strings
+///
+/// \param left  Left operand (a string)
+/// \param right Right operand (a string)
+///
+/// \return True if \a left is lexicographically after or equivalent to \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator >=(const String& left, const String& right);
+
+////////////////////////////////////////////////////////////
+/// \relates String
+/// \brief Overload of binary + operator to concatenate two strings
+///
+/// \param left  Left operand (a string)
+/// \param right Right operand (a string)
+///
+/// \return Concatenated string
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API String operator +(const String& left, const String& right);
+
+#include <SFML/System/String.inl>
+
+} // namespace sf
+
+
+#endif // SFML_STRING_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::String
+/// \ingroup system
+///
+/// sf::String is a utility string class defined mainly for
+/// convenience. It is a Unicode string (implemented using
+/// UTF-32), thus it can store any character in the world
+/// (European, Chinese, Arabic, Hebrew, etc.).
+///
+/// It automatically handles conversions from/to ANSI and
+/// wide strings, so that you can work with standard string
+/// classes and still be compatible with functions taking a
+/// sf::String.
+///
+/// \code
+/// sf::String s;
+///
+/// std::string s1 = s;  // automatically converted to ANSI string
+/// std::wstring s2 = s; // automatically converted to wide string
+/// s = "hello";         // automatically converted from ANSI string
+/// s = L"hello";        // automatically converted from wide string
+/// s += 'a';            // automatically converted from ANSI string
+/// s += L'a';           // automatically converted from wide string
+/// \endcode
+///
+/// Conversions involving ANSI strings use the default user locale. However
+/// it is possible to use a custom locale if necessary:
+/// \code
+/// std::locale locale;
+/// sf::String s;
+/// ...
+/// std::string s1 = s.toAnsiString(locale);
+/// s = sf::String("hello", locale);
+/// \endcode
+///
+/// sf::String defines the most important functions of the
+/// standard std::string class: removing, random access, iterating,
+/// appending, comparing, etc. However it is a simple class
+/// provided for convenience, and you may have to consider using
+/// a more optimized class if your program requires complex string
+/// handling. The automatic conversion functions will then take
+/// care of converting your string to sf::String whenever SFML
+/// requires it.
+///
+/// Please note that SFML also defines a low-level, generic
+/// interface for Unicode handling, see the sf::Utf classes.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/String.inl
+++ b/libs/include/SFML/System/String.inl
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+String String::fromUtf8(T begin, T end)
+{
+    String string;
+    Utf8::toUtf32(begin, end, std::back_inserter(string.m_string));
+    return string;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+String String::fromUtf16(T begin, T end)
+{
+    String string;
+    Utf16::toUtf32(begin, end, std::back_inserter(string.m_string));
+    return string;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+String String::fromUtf32(T begin, T end)
+{
+    String string;
+    string.m_string.assign(begin, end);
+    return string;
+}

--- a/libs/include/SFML/System/Thread.hpp
+++ b/libs/include/SFML/System/Thread.hpp
@@ -1,0 +1,282 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_THREAD_HPP
+#define SFML_THREAD_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <cstdlib>
+
+
+namespace sf
+{
+namespace priv
+{
+    class ThreadImpl;
+    struct ThreadFunc;
+}
+
+////////////////////////////////////////////////////////////
+/// \brief Utility class to manipulate threads
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API Thread : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the thread from a functor with no argument
+    ///
+    /// This constructor works for function objects, as well
+    /// as free functions.
+    ///
+    /// Use this constructor for this kind of function:
+    /// \code
+    /// void function();
+    ///
+    /// // --- or ----
+    ///
+    /// struct Functor
+    /// {
+    ///     void operator()();
+    /// };
+    /// \endcode
+    /// Note: this does *not* run the thread, use launch().
+    ///
+    /// \param function Functor or free function to use as the entry point of the thread
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename F>
+    Thread(F function);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the thread from a functor with an argument
+    ///
+    /// This constructor works for function objects, as well
+    /// as free functions.
+    /// It is a template, which means that the argument can
+    /// have any type (int, std::string, void*, Toto, ...).
+    ///
+    /// Use this constructor for this kind of function:
+    /// \code
+    /// void function(int arg);
+    ///
+    /// // --- or ----
+    ///
+    /// struct Functor
+    /// {
+    ///     void operator()(std::string arg);
+    /// };
+    /// \endcode
+    /// Note: this does *not* run the thread, use launch().
+    ///
+    /// \param function Functor or free function to use as the entry point of the thread
+    /// \param argument argument to forward to the function
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename F, typename A>
+    Thread(F function, A argument);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the thread from a member function and an object
+    ///
+    /// This constructor is a template, which means that you can
+    /// use it with any class.
+    /// Use this constructor for this kind of function:
+    /// \code
+    /// class MyClass
+    /// {
+    /// public:
+    ///
+    ///     void function();
+    /// };
+    /// \endcode
+    /// Note: this does *not* run the thread, use launch().
+    ///
+    /// \param function Entry point of the thread
+    /// \param object Pointer to the object to use
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename C>
+    Thread(void(C::*function)(), C* object);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// This destructor calls wait(), so that the internal thread
+    /// cannot survive after its sf::Thread instance is destroyed.
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Thread();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Run the thread
+    ///
+    /// This function starts the entry point passed to the
+    /// thread's constructor, and returns immediately.
+    /// After this function returns, the thread's function is
+    /// running in parallel to the calling code.
+    ///
+    ////////////////////////////////////////////////////////////
+    void launch();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Wait until the thread finishes
+    ///
+    /// This function will block the execution until the
+    /// thread's function ends.
+    /// Warning: if the thread function never ends, the calling
+    /// thread will block forever.
+    /// If this function is called from its owner thread, it
+    /// returns without doing anything.
+    ///
+    ////////////////////////////////////////////////////////////
+    void wait();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Terminate the thread
+    ///
+    /// This function immediately stops the thread, without waiting
+    /// for its function to finish.
+    /// Terminating a thread with this function is not safe,
+    /// and can lead to local variables not being destroyed
+    /// on some operating systems. You should rather try to make
+    /// the thread function terminate by itself.
+    ///
+    ////////////////////////////////////////////////////////////
+    void terminate();
+
+private:
+
+    friend class priv::ThreadImpl;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Internal entry point of the thread
+    ///
+    /// This function is called by the thread implementation.
+    ///
+    ////////////////////////////////////////////////////////////
+    void run();
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    priv::ThreadImpl* m_impl;       ///< OS-specific implementation of the thread
+    priv::ThreadFunc* m_entryPoint; ///< Abstraction of the function to run
+};
+
+#include <SFML/System/Thread.inl>
+
+} // namespace sf
+
+#endif // SFML_THREAD_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Thread
+/// \ingroup system
+///
+/// Threads provide a way to run multiple parts of the code
+/// in parallel. When you launch a new thread, the execution
+/// is split and both the new thread and the caller run
+/// in parallel.
+///
+/// To use a sf::Thread, you construct it directly with the
+/// function to execute as the entry point of the thread.
+/// sf::Thread has multiple template constructors, which means
+/// that you can use several types of entry points:
+/// \li non-member functions with no argument
+/// \li non-member functions with one argument of any type
+/// \li functors with no argument (this one is particularly useful for compatibility with boost/std::%bind)
+/// \li functors with one argument of any type
+/// \li member functions from any class with no argument
+///
+/// The function argument, if any, is copied in the sf::Thread
+/// instance, as well as the functor (if the corresponding
+/// constructor is used). Class instances, however, are passed
+/// by pointer so you must make sure that the object won't be
+/// destroyed while the thread is still using it.
+///
+/// The thread ends when its function is terminated. If the
+/// owner sf::Thread instance is destroyed before the
+/// thread is finished, the destructor will wait (see wait())
+///
+/// Usage examples:
+/// \code
+/// // example 1: non member function with one argument
+///
+/// void threadFunc(int argument)
+/// {
+///     ...
+/// }
+///
+/// sf::Thread thread(&threadFunc, 5);
+/// thread.launch(); // start the thread (internally calls threadFunc(5))
+/// \endcode
+///
+/// \code
+/// // example 2: member function
+///
+/// class Task
+/// {
+/// public:
+///     void run()
+///     {
+///         ...
+///     }
+/// };
+///
+/// Task task;
+/// sf::Thread thread(&Task::run, &task);
+/// thread.launch(); // start the thread (internally calls task.run())
+/// \endcode
+///
+/// \code
+/// // example 3: functor
+///
+/// struct Task
+/// {
+///     void operator()()
+///     {
+///         ...
+///     }
+/// };
+///
+/// sf::Thread thread(Task());
+/// thread.launch(); // start the thread (internally calls operator() on the Task instance)
+/// \endcode
+///
+/// Creating parallel threads of execution can be dangerous:
+/// all threads inside the same process share the same memory space,
+/// which means that you may end up accessing the same variable
+/// from multiple threads at the same time. To prevent this
+/// kind of situations, you can use mutexes (see sf::Mutex).
+///
+/// \see sf::Mutex
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Thread.inl
+++ b/libs/include/SFML/System/Thread.inl
@@ -1,0 +1,90 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+namespace priv
+{
+// Base class for abstract thread functions
+struct ThreadFunc
+{
+    virtual ~ThreadFunc() {}
+    virtual void run() = 0;
+};
+
+// Specialization using a functor (including free functions) with no argument
+template <typename T>
+struct ThreadFunctor : ThreadFunc
+{
+    ThreadFunctor(T functor) : m_functor(functor) {}
+    virtual void run() {m_functor();}
+    T m_functor;
+};
+
+// Specialization using a functor (including free functions) with one argument
+template <typename F, typename A>
+struct ThreadFunctorWithArg : ThreadFunc
+{
+    ThreadFunctorWithArg(F function, A arg) : m_function(function), m_arg(arg) {}
+    virtual void run() {m_function(m_arg);}
+    F m_function;
+    A m_arg;
+};
+
+// Specialization using a member function
+template <typename C>
+struct ThreadMemberFunc : ThreadFunc
+{
+    ThreadMemberFunc(void(C::*function)(), C* object) : m_function(function), m_object(object) {}
+    virtual void run() {(m_object->*m_function)();}
+    void(C::*m_function)();
+    C* m_object;
+};
+
+} // namespace priv
+
+
+////////////////////////////////////////////////////////////
+template <typename F>
+Thread::Thread(F functor) :
+m_impl      (NULL),
+m_entryPoint(new priv::ThreadFunctor<F>(functor))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename F, typename A>
+Thread::Thread(F function, A argument) :
+m_impl      (NULL),
+m_entryPoint(new priv::ThreadFunctorWithArg<F, A>(function, argument))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename C>
+Thread::Thread(void(C::*function)(), C* object) :
+m_impl      (NULL),
+m_entryPoint(new priv::ThreadMemberFunc<C>(function, object))
+{
+}

--- a/libs/include/SFML/System/ThreadLocal.hpp
+++ b/libs/include/SFML/System/ThreadLocal.hpp
@@ -1,0 +1,103 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_THREADLOCAL_HPP
+#define SFML_THREADLOCAL_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <cstdlib>
+
+
+namespace sf
+{
+namespace priv
+{
+    class ThreadLocalImpl;
+}
+
+////////////////////////////////////////////////////////////
+/// \brief Defines variables with thread-local storage
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API ThreadLocal : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// \param value Optional value to initialize the variable
+    ///
+    ////////////////////////////////////////////////////////////
+    ThreadLocal(void* value = NULL);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~ThreadLocal();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the thread-specific value of the variable
+    ///
+    /// \param value Value of the variable for the current thread
+    ///
+    ////////////////////////////////////////////////////////////
+    void setValue(void* value);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Retrieve the thread-specific value of the variable
+    ///
+    /// \return Value of the variable for the current thread
+    ///
+    ////////////////////////////////////////////////////////////
+    void* getValue() const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    priv::ThreadLocalImpl* m_impl; ///< Pointer to the OS specific implementation
+};
+
+} // namespace sf
+
+
+#endif // SFML_THREADLOCAL_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::ThreadLocal
+/// \ingroup system
+///
+/// This class manipulates void* parameters and thus is not
+/// appropriate for strongly-typed variables. You should rather
+/// use the sf::ThreadLocalPtr template class.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/ThreadLocalPtr.hpp
+++ b/libs/include/SFML/System/ThreadLocalPtr.hpp
@@ -1,0 +1,158 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_THREADLOCALPTR_HPP
+#define SFML_THREADLOCALPTR_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/ThreadLocal.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Pointer to a thread-local variable
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+class ThreadLocalPtr : private ThreadLocal
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// \param value Optional value to initialize the variable
+    ///
+    ////////////////////////////////////////////////////////////
+    ThreadLocalPtr(T* value = NULL);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of unary operator *
+    ///
+    /// Like raw pointers, applying the * operator returns a
+    /// reference to the pointed-to object.
+    ///
+    /// \return Reference to the thread-local variable
+    ///
+    ////////////////////////////////////////////////////////////
+    T& operator *() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Overload of operator ->
+    ///
+    /// Similarly to raw pointers, applying the -> operator
+    /// returns the pointed-to object.
+    ///
+    /// \return Pointer to the thread-local variable
+    ///
+    ////////////////////////////////////////////////////////////
+    T* operator ->() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Conversion operator to implicitly convert the
+    ///        pointer to its raw pointer type (T*)
+    ///
+    /// \return Pointer to the actual object
+    ///
+    ////////////////////////////////////////////////////////////
+    operator T*() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Assignment operator for a raw pointer parameter
+    ///
+    /// \param value Pointer to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    ThreadLocalPtr<T>& operator =(T* value);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Assignment operator for a ThreadLocalPtr parameter
+    ///
+    /// \param right ThreadLocalPtr to assign
+    ///
+    /// \return Reference to self
+    ///
+    ////////////////////////////////////////////////////////////
+    ThreadLocalPtr<T>& operator =(const ThreadLocalPtr<T>& right);
+};
+
+} // namespace sf
+
+#include <SFML/System/ThreadLocalPtr.inl>
+
+
+#endif // SFML_THREADLOCALPTR_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::ThreadLocalPtr
+/// \ingroup system
+///
+/// sf::ThreadLocalPtr is a type-safe wrapper for storing
+/// pointers to thread-local variables. A thread-local
+/// variable holds a different value for each different
+/// thread, unlike normal variables that are shared.
+///
+/// Its usage is completely transparent, so that it is similar
+/// to manipulating the raw pointer directly (like any smart pointer).
+///
+/// Usage example:
+/// \code
+/// MyClass object1;
+/// MyClass object2;
+/// sf::ThreadLocalPtr<MyClass> objectPtr;
+///
+/// void thread1()
+/// {
+///     objectPtr = &object1; // doesn't impact thread2
+///     ...
+/// }
+///
+/// void thread2()
+/// {
+///     objectPtr = &object2; // doesn't impact thread1
+///     ...
+/// }
+///
+/// int main()
+/// {
+///     // Create and launch the two threads
+///     sf::Thread t1(&thread1);
+///     sf::Thread t2(&thread2);
+///     t1.launch();
+///     t2.launch();
+///
+///     return 0;
+/// }
+/// \endcode
+///
+/// ThreadLocalPtr is designed for internal use; however you
+/// can use it if you feel like it fits well your implementation.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/ThreadLocalPtr.inl
+++ b/libs/include/SFML/System/ThreadLocalPtr.inl
@@ -1,0 +1,77 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+template <typename T>
+ThreadLocalPtr<T>::ThreadLocalPtr(T* value) :
+ThreadLocal(value)
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+T& ThreadLocalPtr<T>::operator *() const
+{
+    return *static_cast<T*>(getValue());
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+T* ThreadLocalPtr<T>::operator ->() const
+{
+    return static_cast<T*>(getValue());
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+ThreadLocalPtr<T>::operator T*() const
+{
+    return static_cast<T*>(getValue());
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+ThreadLocalPtr<T>& ThreadLocalPtr<T>::operator =(T* value)
+{
+    setValue(value);
+    return *this;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+ThreadLocalPtr<T>& ThreadLocalPtr<T>::operator =(const ThreadLocalPtr<T>& right)
+{
+    setValue(right.getValue());
+    return *this;
+}
+
+} // namespace sf

--- a/libs/include/SFML/System/Time.hpp
+++ b/libs/include/SFML/System/Time.hpp
@@ -1,0 +1,488 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_TIME_HPP
+#define SFML_TIME_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/System/Export.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Represents a time value
+///
+////////////////////////////////////////////////////////////
+class SFML_SYSTEM_API Time
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Sets the time value to zero.
+    ///
+    ////////////////////////////////////////////////////////////
+    Time();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the time value as a number of seconds
+    ///
+    /// \return Time in seconds
+    ///
+    /// \see asMilliseconds, asMicroseconds
+    ///
+    ////////////////////////////////////////////////////////////
+    float asSeconds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the time value as a number of milliseconds
+    ///
+    /// \return Time in milliseconds
+    ///
+    /// \see asSeconds, asMicroseconds
+    ///
+    ////////////////////////////////////////////////////////////
+    Int32 asMilliseconds() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the time value as a number of microseconds
+    ///
+    /// \return Time in microseconds
+    ///
+    /// \see asSeconds, asMilliseconds
+    ///
+    ////////////////////////////////////////////////////////////
+    Int64 asMicroseconds() const;
+
+    ////////////////////////////////////////////////////////////
+    // Static member data
+    ////////////////////////////////////////////////////////////
+    static const Time Zero; ///< Predefined "zero" time value
+
+private:
+
+    friend SFML_SYSTEM_API Time seconds(float);
+    friend SFML_SYSTEM_API Time milliseconds(Int32);
+    friend SFML_SYSTEM_API Time microseconds(Int64);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct from a number of microseconds
+    ///
+    /// This function is internal. To construct time values,
+    /// use sf::seconds, sf::milliseconds or sf::microseconds instead.
+    ///
+    /// \param microseconds Number of microseconds
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Time(Int64 microseconds);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    Int64 m_microseconds; ///< Time value stored as microseconds
+};
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Construct a time value from a number of seconds
+///
+/// \param amount Number of seconds
+///
+/// \return Time value constructed from the amount of seconds
+///
+/// \see milliseconds, microseconds
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time seconds(float amount);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Construct a time value from a number of milliseconds
+///
+/// \param amount Number of milliseconds
+///
+/// \return Time value constructed from the amount of milliseconds
+///
+/// \see seconds, microseconds
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time milliseconds(Int32 amount);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Construct a time value from a number of microseconds
+///
+/// \param amount Number of microseconds
+///
+/// \return Time value constructed from the amount of microseconds
+///
+/// \see seconds, milliseconds
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time microseconds(Int64 amount);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of == operator to compare two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return True if both time values are equal
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator ==(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of != operator to compare two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return True if both time values are different
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator !=(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of < operator to compare two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return True if \a left is lesser than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator <(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of > operator to compare two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return True if \a left is greater than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator >(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of <= operator to compare two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return True if \a left is lesser or equal than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator <=(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of >= operator to compare two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return True if \a left is greater or equal than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API bool operator >=(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of unary - operator to negate a time value
+///
+/// \param right Right operand (a time)
+///
+/// \return Opposite of the time value
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator -(Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary + operator to add two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return Sum of the two times values
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator +(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary += operator to add/assign two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return Sum of the two times values
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time& operator +=(Time& left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary - operator to subtract two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return Difference of the two times values
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator -(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary -= operator to subtract/assign two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return Difference of the two times values
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time& operator -=(Time& left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary * operator to scale a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a number)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator *(Time left, float right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary * operator to scale a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a number)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator *(Time left, Int64 right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary * operator to scale a time value
+///
+/// \param left  Left operand (a number)
+/// \param right Right operand (a time)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator *(float left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary * operator to scale a time value
+///
+/// \param left  Left operand (a number)
+/// \param right Right operand (a time)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator *(Int64 left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary *= operator to scale/assign a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a number)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time& operator *=(Time& left, float right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary *= operator to scale/assign a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a number)
+///
+/// \return \a left multiplied by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time& operator *=(Time& left, Int64 right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary / operator to scale a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a number)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator /(Time left, float right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary / operator to scale a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a number)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator /(Time left, Int64 right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary /= operator to scale/assign a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a number)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time& operator /=(Time& left, float right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary /= operator to scale/assign a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a number)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time& operator /=(Time& left, Int64 right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary / operator to compute the ratio of two time values
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return \a left divided by \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API float operator /(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary % operator to compute remainder of a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return \a left modulo \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time operator %(Time left, Time right);
+
+////////////////////////////////////////////////////////////
+/// \relates Time
+/// \brief Overload of binary %= operator to compute/assign remainder of a time value
+///
+/// \param left  Left operand (a time)
+/// \param right Right operand (a time)
+///
+/// \return \a left modulo \a right
+///
+////////////////////////////////////////////////////////////
+SFML_SYSTEM_API Time& operator %=(Time& left, Time right);
+
+} // namespace sf
+
+
+#endif // SFML_TIME_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Time
+/// \ingroup system
+///
+/// sf::Time encapsulates a time value in a flexible way.
+/// It allows to define a time value either as a number of
+/// seconds, milliseconds or microseconds. It also works the
+/// other way round: you can read a time value as either
+/// a number of seconds, milliseconds or microseconds.
+///
+/// By using such a flexible interface, the API doesn't
+/// impose any fixed type or resolution for time values,
+/// and let the user choose its own favorite representation.
+///
+/// Time values support the usual mathematical operations:
+/// you can add or subtract two times, multiply or divide
+/// a time by a number, compare two times, etc.
+///
+/// Since they represent a time span and not an absolute time
+/// value, times can also be negative.
+///
+/// Usage example:
+/// \code
+/// sf::Time t1 = sf::seconds(0.1f);
+/// Int32 milli = t1.asMilliseconds(); // 100
+///
+/// sf::Time t2 = sf::milliseconds(30);
+/// Int64 micro = t2.asMicroseconds(); // 30000
+///
+/// sf::Time t3 = sf::microseconds(-800000);
+/// float sec = t3.asSeconds(); // -0.8
+/// \endcode
+///
+/// \code
+/// void update(sf::Time elapsed)
+/// {
+///    position += speed * elapsed.asSeconds();
+/// }
+///
+/// update(sf::milliseconds(100));
+/// \endcode
+///
+/// \see sf::Clock
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Utf.hpp
+++ b/libs/include/SFML/System/Utf.hpp
@@ -1,0 +1,763 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_UTF_HPP
+#define SFML_UTF_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+#include <algorithm>
+#include <locale>
+#include <string>
+#include <cstdlib>
+
+
+namespace sf
+{
+template <unsigned int N>
+class Utf;
+
+////////////////////////////////////////////////////////////
+/// \brief Specialization of the Utf template for UTF-8
+///
+////////////////////////////////////////////////////////////
+template <>
+class Utf<8>
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Decode a single UTF-8 character
+    ///
+    /// Decoding a character means finding its unique 32-bits
+    /// code (called the codepoint) in the Unicode standard.
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Codepoint of the decoded UTF-8 character
+    /// \param replacement Replacement character to use in case the UTF-8 sequence is invalid
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static In decode(In begin, In end, Uint32& output, Uint32 replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Encode a single UTF-8 character
+    ///
+    /// Encoding a character means converting a unique 32-bits
+    /// code (called the codepoint) in the target encoding, UTF-8.
+    ///
+    /// \param input       Codepoint to encode as UTF-8
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-8 (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename Out>
+    static Out encode(Uint32 input, Out output, Uint8 replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Advance to the next UTF-8 character
+    ///
+    /// This function is necessary for multi-elements encodings, as
+    /// a single character may use more than 1 storage element.
+    ///
+    /// \param begin Iterator pointing to the beginning of the input sequence
+    /// \param end   Iterator pointing to the end of the input sequence
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static In next(In begin, In end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Count the number of characters of a UTF-8 sequence
+    ///
+    /// This function is necessary for multi-elements encodings, as
+    /// a single character may use more than 1 storage element, thus the
+    /// total size can be different from (begin - end).
+    ///
+    /// \param begin Iterator pointing to the beginning of the input sequence
+    /// \param end   Iterator pointing to the end of the input sequence
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static std::size_t count(In begin, In end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an ANSI characters range to UTF-8
+    ///
+    /// The current global locale will be used by default, unless you
+    /// pass a custom one in the \a locale parameter.
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param locale Locale to use for conversion
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromAnsi(In begin, In end, Out output, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a wide characters range to UTF-8
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromWide(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a latin-1 (ISO-5589-1) characters range to UTF-8
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromLatin1(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-8 characters range to ANSI characters
+    ///
+    /// The current global locale will be used by default, unless you
+    /// pass a custom one in the \a locale parameter.
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to ANSI (use 0 to skip them)
+    /// \param locale      Locale to use for conversion
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toAnsi(In begin, In end, Out output, char replacement = 0, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-8 characters range to wide characters
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toWide(In begin, In end, Out output, wchar_t replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-8 characters range to latin-1 (ISO-5589-1) characters
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toLatin1(In begin, In end, Out output, char replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-8 characters range to UTF-8
+    ///
+    /// This functions does nothing more than a direct copy;
+    /// it is defined only to provide the same interface as other
+    /// specializations of the sf::Utf<> template, and allow
+    /// generic code to be written on top of it.
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf8(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-8 characters range to UTF-16
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf16(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-8 characters range to UTF-32
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf32(In begin, In end, Out output);
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Specialization of the Utf template for UTF-16
+///
+////////////////////////////////////////////////////////////
+template <>
+class Utf<16>
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Decode a single UTF-16 character
+    ///
+    /// Decoding a character means finding its unique 32-bits
+    /// code (called the codepoint) in the Unicode standard.
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Codepoint of the decoded UTF-16 character
+    /// \param replacement Replacement character to use in case the UTF-8 sequence is invalid
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static In decode(In begin, In end, Uint32& output, Uint32 replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Encode a single UTF-16 character
+    ///
+    /// Encoding a character means converting a unique 32-bits
+    /// code (called the codepoint) in the target encoding, UTF-16.
+    ///
+    /// \param input       Codepoint to encode as UTF-16
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-16 (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename Out>
+    static Out encode(Uint32 input, Out output, Uint16 replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Advance to the next UTF-16 character
+    ///
+    /// This function is necessary for multi-elements encodings, as
+    /// a single character may use more than 1 storage element.
+    ///
+    /// \param begin Iterator pointing to the beginning of the input sequence
+    /// \param end   Iterator pointing to the end of the input sequence
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static In next(In begin, In end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Count the number of characters of a UTF-16 sequence
+    ///
+    /// This function is necessary for multi-elements encodings, as
+    /// a single character may use more than 1 storage element, thus the
+    /// total size can be different from (begin - end).
+    ///
+    /// \param begin Iterator pointing to the beginning of the input sequence
+    /// \param end   Iterator pointing to the end of the input sequence
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static std::size_t count(In begin, In end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an ANSI characters range to UTF-16
+    ///
+    /// The current global locale will be used by default, unless you
+    /// pass a custom one in the \a locale parameter.
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param locale Locale to use for conversion
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromAnsi(In begin, In end, Out output, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a wide characters range to UTF-16
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromWide(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a latin-1 (ISO-5589-1) characters range to UTF-16
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromLatin1(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-16 characters range to ANSI characters
+    ///
+    /// The current global locale will be used by default, unless you
+    /// pass a custom one in the \a locale parameter.
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to ANSI (use 0 to skip them)
+    /// \param locale      Locale to use for conversion
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toAnsi(In begin, In end, Out output, char replacement = 0, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-16 characters range to wide characters
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toWide(In begin, In end, Out output, wchar_t replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-16 characters range to latin-1 (ISO-5589-1) characters
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toLatin1(In begin, In end, Out output, char replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-16 characters range to UTF-8
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf8(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-16 characters range to UTF-16
+    ///
+    /// This functions does nothing more than a direct copy;
+    /// it is defined only to provide the same interface as other
+    /// specializations of the sf::Utf<> template, and allow
+    /// generic code to be written on top of it.
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf16(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-16 characters range to UTF-32
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf32(In begin, In end, Out output);
+};
+
+////////////////////////////////////////////////////////////
+/// \brief Specialization of the Utf template for UTF-32
+///
+////////////////////////////////////////////////////////////
+template <>
+class Utf<32>
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Decode a single UTF-32 character
+    ///
+    /// Decoding a character means finding its unique 32-bits
+    /// code (called the codepoint) in the Unicode standard.
+    /// For UTF-32, the character value is the same as the codepoint.
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Codepoint of the decoded UTF-32 character
+    /// \param replacement Replacement character to use in case the UTF-8 sequence is invalid
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static In decode(In begin, In end, Uint32& output, Uint32 replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Encode a single UTF-32 character
+    ///
+    /// Encoding a character means converting a unique 32-bits
+    /// code (called the codepoint) in the target encoding, UTF-32.
+    /// For UTF-32, the codepoint is the same as the character value.
+    ///
+    /// \param input       Codepoint to encode as UTF-32
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to UTF-32 (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename Out>
+    static Out encode(Uint32 input, Out output, Uint32 replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Advance to the next UTF-32 character
+    ///
+    /// This function is trivial for UTF-32, which can store
+    /// every character in a single storage element.
+    ///
+    /// \param begin Iterator pointing to the beginning of the input sequence
+    /// \param end   Iterator pointing to the end of the input sequence
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static In next(In begin, In end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Count the number of characters of a UTF-32 sequence
+    ///
+    /// This function is trivial for UTF-32, which can store
+    /// every character in a single storage element.
+    ///
+    /// \param begin Iterator pointing to the beginning of the input sequence
+    /// \param end   Iterator pointing to the end of the input sequence
+    ///
+    /// \return Iterator pointing to one past the last read element of the input sequence
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static std::size_t count(In begin, In end);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an ANSI characters range to UTF-32
+    ///
+    /// The current global locale will be used by default, unless you
+    /// pass a custom one in the \a locale parameter.
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    /// \param locale Locale to use for conversion
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromAnsi(In begin, In end, Out output, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a wide characters range to UTF-32
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromWide(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a latin-1 (ISO-5589-1) characters range to UTF-32
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out fromLatin1(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-32 characters range to ANSI characters
+    ///
+    /// The current global locale will be used by default, unless you
+    /// pass a custom one in the \a locale parameter.
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to ANSI (use 0 to skip them)
+    /// \param locale      Locale to use for conversion
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toAnsi(In begin, In end, Out output, char replacement = 0, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-32 characters range to wide characters
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toWide(In begin, In end, Out output, wchar_t replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert an UTF-16 characters range to latin-1 (ISO-5589-1) characters
+    ///
+    /// \param begin       Iterator pointing to the beginning of the input sequence
+    /// \param end         Iterator pointing to the end of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement for characters not convertible to wide (use 0 to skip them)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toLatin1(In begin, In end, Out output, char replacement = 0);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-32 characters range to UTF-8
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf8(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-32 characters range to UTF-16
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf16(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Convert a UTF-32 characters range to UTF-32
+    ///
+    /// This functions does nothing more than a direct copy;
+    /// it is defined only to provide the same interface as other
+    /// specializations of the sf::Utf<> template, and allow
+    /// generic code to be written on top of it.
+    ///
+    /// \param begin  Iterator pointing to the beginning of the input sequence
+    /// \param end    Iterator pointing to the end of the input sequence
+    /// \param output Iterator pointing to the beginning of the output sequence
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In, typename Out>
+    static Out toUtf32(In begin, In end, Out output);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Decode a single ANSI character to UTF-32
+    ///
+    /// This function does not exist in other specializations
+    /// of sf::Utf<>, it is defined for convenience (it is used by
+    /// several other conversion functions).
+    ///
+    /// \param input  Input ANSI character
+    /// \param locale Locale to use for conversion
+    ///
+    /// \return Converted character
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static Uint32 decodeAnsi(In input, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Decode a single wide character to UTF-32
+    ///
+    /// This function does not exist in other specializations
+    /// of sf::Utf<>, it is defined for convenience (it is used by
+    /// several other conversion functions).
+    ///
+    /// \param input Input wide character
+    ///
+    /// \return Converted character
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename In>
+    static Uint32 decodeWide(In input);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Encode a single UTF-32 character to ANSI
+    ///
+    /// This function does not exist in other specializations
+    /// of sf::Utf<>, it is defined for convenience (it is used by
+    /// several other conversion functions).
+    ///
+    /// \param codepoint   Iterator pointing to the beginning of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement if the input character is not convertible to ANSI (use 0 to skip it)
+    /// \param locale      Locale to use for conversion
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename Out>
+    static Out encodeAnsi(Uint32 codepoint, Out output, char replacement = 0, const std::locale& locale = std::locale());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Encode a single UTF-32 character to wide
+    ///
+    /// This function does not exist in other specializations
+    /// of sf::Utf<>, it is defined for convenience (it is used by
+    /// several other conversion functions).
+    ///
+    /// \param codepoint   Iterator pointing to the beginning of the input sequence
+    /// \param output      Iterator pointing to the beginning of the output sequence
+    /// \param replacement Replacement if the input character is not convertible to wide (use 0 to skip it)
+    ///
+    /// \return Iterator to the end of the output sequence which has been written
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename Out>
+    static Out encodeWide(Uint32 codepoint, Out output, wchar_t replacement = 0);
+};
+
+#include <SFML/System/Utf.inl>
+
+// Make typedefs to get rid of the template syntax
+typedef Utf<8>  Utf8;
+typedef Utf<16> Utf16;
+typedef Utf<32> Utf32;
+
+} // namespace sf
+
+
+#endif // SFML_UTF_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Utf
+/// \ingroup system
+///
+/// Utility class providing generic functions for UTF conversions.
+///
+/// sf::Utf is a low-level, generic interface for counting, iterating,
+/// encoding and decoding Unicode characters and strings. It is able
+/// to handle ANSI, wide, latin-1, UTF-8, UTF-16 and UTF-32 encodings.
+///
+/// sf::Utf<X> functions are all static, these classes are not meant to
+/// be instantiated. All the functions are template, so that you
+/// can use any character / string type for a given encoding.
+///
+/// It has 3 specializations:
+/// \li sf::Utf<8> (typedef'd to sf::Utf8)
+/// \li sf::Utf<16> (typedef'd to sf::Utf16)
+/// \li sf::Utf<32> (typedef'd to sf::Utf32)
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Utf.inl
+++ b/libs/include/SFML/System/Utf.inl
@@ -1,0 +1,752 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+// References:
+//
+// https://www.unicode.org/
+// https://www.unicode.org/Public/PROGRAMS/CVTUTF/ConvertUTF.c
+// https://www.unicode.org/Public/PROGRAMS/CVTUTF/ConvertUTF.h
+// https://people.w3.org/rishida/scripts/uniview/conversion
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+In Utf<8>::decode(In begin, In end, Uint32& output, Uint32 replacement)
+{
+    // Some useful precomputed data
+    static const int trailing[256] =
+    {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+        2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5
+    };
+    static const Uint32 offsets[6] =
+    {
+        0x00000000, 0x00003080, 0x000E2080, 0x03C82080, 0xFA082080, 0x82082080
+    };
+
+    // decode the character
+    int trailingBytes = trailing[static_cast<Uint8>(*begin)];
+    if (begin + trailingBytes < end)
+    {
+        output = 0;
+        switch (trailingBytes)
+        {
+            case 5: output += static_cast<Uint8>(*begin++); output <<= 6;
+            case 4: output += static_cast<Uint8>(*begin++); output <<= 6;
+            case 3: output += static_cast<Uint8>(*begin++); output <<= 6;
+            case 2: output += static_cast<Uint8>(*begin++); output <<= 6;
+            case 1: output += static_cast<Uint8>(*begin++); output <<= 6;
+            case 0: output += static_cast<Uint8>(*begin++);
+        }
+        output -= offsets[trailingBytes];
+    }
+    else
+    {
+        // Incomplete character
+        begin = end;
+        output = replacement;
+    }
+
+    return begin;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Out>
+Out Utf<8>::encode(Uint32 input, Out output, Uint8 replacement)
+{
+    // Some useful precomputed data
+    static const Uint8 firstBytes[7] =
+    {
+        0x00, 0x00, 0xC0, 0xE0, 0xF0, 0xF8, 0xFC
+    };
+
+    // encode the character
+    if ((input > 0x0010FFFF) || ((input >= 0xD800) && (input <= 0xDBFF)))
+    {
+        // Invalid character
+        if (replacement)
+            *output++ = replacement;
+    }
+    else
+    {
+        // Valid character
+
+        // Get the number of bytes to write
+        std::size_t bytestoWrite = 1;
+        if      (input <  0x80)       bytestoWrite = 1;
+        else if (input <  0x800)      bytestoWrite = 2;
+        else if (input <  0x10000)    bytestoWrite = 3;
+        else if (input <= 0x0010FFFF) bytestoWrite = 4;
+
+        // Extract the bytes to write
+        Uint8 bytes[4];
+        switch (bytestoWrite)
+        {
+            case 4: bytes[3] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6;
+            case 3: bytes[2] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6;
+            case 2: bytes[1] = static_cast<Uint8>((input | 0x80) & 0xBF); input >>= 6;
+            case 1: bytes[0] = static_cast<Uint8> (input | firstBytes[bytestoWrite]);
+        }
+
+        // Add them to the output
+        output = std::copy(bytes, bytes + bytestoWrite, output);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+In Utf<8>::next(In begin, In end)
+{
+    Uint32 codepoint;
+    return decode(begin, end, codepoint);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+std::size_t Utf<8>::count(In begin, In end)
+{
+    std::size_t length = 0;
+    while (begin < end)
+    {
+        begin = next(begin, end);
+        ++length;
+    }
+
+    return length;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint = Utf<32>::decodeAnsi(*begin++, locale);
+        output = encode(codepoint, output);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::fromWide(In begin, In end, Out output)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint = Utf<32>::decodeWide(*begin++);
+        output = encode(codepoint, output);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::fromLatin1(In begin, In end, Out output)
+{
+    // Latin-1 is directly compatible with Unicode encodings,
+    // and can thus be treated as (a sub-range of) UTF-32
+    while (begin < end)
+        output = encode(*begin++, output);
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        output = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::toWide(In begin, In end, Out output, wchar_t replacement)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        output = Utf<32>::encodeWide(codepoint, output, replacement);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::toLatin1(In begin, In end, Out output, char replacement)
+{
+    // Latin-1 is directly compatible with Unicode encodings,
+    // and can thus be treated as (a sub-range of) UTF-32
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        *output++ = codepoint < 256 ? static_cast<char>(codepoint) : replacement;
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::toUtf8(In begin, In end, Out output)
+{
+    return std::copy(begin, end, output);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::toUtf16(In begin, In end, Out output)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        output = Utf<16>::encode(codepoint, output);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<8>::toUtf32(In begin, In end, Out output)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        *output++ = codepoint;
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+In Utf<16>::decode(In begin, In end, Uint32& output, Uint32 replacement)
+{
+    Uint16 first = *begin++;
+
+    // If it's a surrogate pair, first convert to a single UTF-32 character
+    if ((first >= 0xD800) && (first <= 0xDBFF))
+    {
+        if (begin < end)
+        {
+            Uint32 second = *begin++;
+            if ((second >= 0xDC00) && (second <= 0xDFFF))
+            {
+                // The second element is valid: convert the two elements to a UTF-32 character
+                output = static_cast<Uint32>(((first - 0xD800) << 10) + (second - 0xDC00) + 0x0010000);
+            }
+            else
+            {
+                // Invalid character
+                output = replacement;
+            }
+        }
+        else
+        {
+            // Invalid character
+            begin = end;
+            output = replacement;
+        }
+    }
+    else
+    {
+        // We can make a direct copy
+        output = first;
+    }
+
+    return begin;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Out>
+Out Utf<16>::encode(Uint32 input, Out output, Uint16 replacement)
+{
+    if (input <= 0xFFFF)
+    {
+        // The character can be copied directly, we just need to check if it's in the valid range
+        if ((input >= 0xD800) && (input <= 0xDFFF))
+        {
+            // Invalid character (this range is reserved)
+            if (replacement)
+                *output++ = replacement;
+        }
+        else
+        {
+            // Valid character directly convertible to a single UTF-16 character
+            *output++ = static_cast<Uint16>(input);
+        }
+    }
+    else if (input > 0x0010FFFF)
+    {
+        // Invalid character (greater than the maximum Unicode value)
+        if (replacement)
+            *output++ = replacement;
+    }
+    else
+    {
+        // The input character will be converted to two UTF-16 elements
+        input -= 0x0010000;
+        *output++ = static_cast<Uint16>((input >> 10)     + 0xD800);
+        *output++ = static_cast<Uint16>((input & 0x3FFUL) + 0xDC00);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+In Utf<16>::next(In begin, In end)
+{
+    Uint32 codepoint;
+    return decode(begin, end, codepoint);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+std::size_t Utf<16>::count(In begin, In end)
+{
+    std::size_t length = 0;
+    while (begin < end)
+    {
+        begin = next(begin, end);
+        ++length;
+    }
+
+    return length;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint = Utf<32>::decodeAnsi(*begin++, locale);
+        output = encode(codepoint, output);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::fromWide(In begin, In end, Out output)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint = Utf<32>::decodeWide(*begin++);
+        output = encode(codepoint, output);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::fromLatin1(In begin, In end, Out output)
+{
+    // Latin-1 is directly compatible with Unicode encodings,
+    // and can thus be treated as (a sub-range of) UTF-32
+    return std::copy(begin, end, output);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        output = Utf<32>::encodeAnsi(codepoint, output, replacement, locale);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::toWide(In begin, In end, Out output, wchar_t replacement)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        output = Utf<32>::encodeWide(codepoint, output, replacement);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::toLatin1(In begin, In end, Out output, char replacement)
+{
+    // Latin-1 is directly compatible with Unicode encodings,
+    // and can thus be treated as (a sub-range of) UTF-32
+    while (begin < end)
+    {
+        *output++ = *begin < 256 ? static_cast<char>(*begin) : replacement;
+        begin++;
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::toUtf8(In begin, In end, Out output)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        output = Utf<8>::encode(codepoint, output);
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::toUtf16(In begin, In end, Out output)
+{
+    return std::copy(begin, end, output);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<16>::toUtf32(In begin, In end, Out output)
+{
+    while (begin < end)
+    {
+        Uint32 codepoint;
+        begin = decode(begin, end, codepoint);
+        *output++ = codepoint;
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+In Utf<32>::decode(In begin, In /*end*/, Uint32& output, Uint32 /*replacement*/)
+{
+    output = *begin++;
+    return begin;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Out>
+Out Utf<32>::encode(Uint32 input, Out output, Uint32 /*replacement*/)
+{
+    *output++ = input;
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+In Utf<32>::next(In begin, In /*end*/)
+{
+    return ++begin;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+std::size_t Utf<32>::count(In begin, In end)
+{
+    return begin - end;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::fromAnsi(In begin, In end, Out output, const std::locale& locale)
+{
+    while (begin < end)
+        *output++ = decodeAnsi(*begin++, locale);
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::fromWide(In begin, In end, Out output)
+{
+    while (begin < end)
+        *output++ = decodeWide(*begin++);
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::fromLatin1(In begin, In end, Out output)
+{
+    // Latin-1 is directly compatible with Unicode encodings,
+    // and can thus be treated as (a sub-range of) UTF-32
+    return std::copy(begin, end, output);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::toAnsi(In begin, In end, Out output, char replacement, const std::locale& locale)
+{
+    while (begin < end)
+        output = encodeAnsi(*begin++, output, replacement, locale);
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::toWide(In begin, In end, Out output, wchar_t replacement)
+{
+    while (begin < end)
+        output = encodeWide(*begin++, output, replacement);
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::toLatin1(In begin, In end, Out output, char replacement)
+{
+    // Latin-1 is directly compatible with Unicode encodings,
+    // and can thus be treated as (a sub-range of) UTF-32
+    while (begin < end)
+    {
+        *output++ = *begin < 256 ? static_cast<char>(*begin) : replacement;
+        begin++;
+    }
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::toUtf8(In begin, In end, Out output)
+{
+    while (begin < end)
+        output = Utf<8>::encode(*begin++, output);
+
+    return output;
+}
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::toUtf16(In begin, In end, Out output)
+{
+    while (begin < end)
+        output = Utf<16>::encode(*begin++, output);
+
+    return output;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In, typename Out>
+Out Utf<32>::toUtf32(In begin, In end, Out output)
+{
+    return std::copy(begin, end, output);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+Uint32 Utf<32>::decodeAnsi(In input, const std::locale& locale)
+{
+    // On Windows, GCC's standard library (glibc++) has almost
+    // no support for Unicode stuff. As a consequence, in this
+    // context we can only use the default locale and ignore
+    // the one passed as parameter.
+
+    #if defined(SFML_SYSTEM_WINDOWS) &&                       /* if Windows ... */                          \
+       (defined(__GLIBCPP__) || defined (__GLIBCXX__)) &&     /* ... and standard library is glibc++ ... */ \
+      !(defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)) /* ... and STLPort is not used on top of it */
+
+        (void)locale; // to avoid warnings
+
+        wchar_t character = 0;
+        mbtowc(&character, &input, 1);
+        return static_cast<Uint32>(character);
+
+    #else
+
+        // Get the facet of the locale which deals with character conversion
+        const std::ctype<wchar_t>& facet = std::use_facet< std::ctype<wchar_t> >(locale);
+
+        // Use the facet to convert each character of the input string
+        return static_cast<Uint32>(facet.widen(input));
+
+    #endif
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename In>
+Uint32 Utf<32>::decodeWide(In input)
+{
+    // The encoding of wide characters is not well defined and is left to the system;
+    // however we can safely assume that it is UCS-2 on Windows and
+    // UCS-4 on Unix systems.
+    // In both cases, a simple copy is enough (UCS-2 is a subset of UCS-4,
+    // and UCS-4 *is* UTF-32).
+
+    return input;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Out>
+Out Utf<32>::encodeAnsi(Uint32 codepoint, Out output, char replacement, const std::locale& locale)
+{
+    // On Windows, gcc's standard library (glibc++) has almost
+    // no support for Unicode stuff. As a consequence, in this
+    // context we can only use the default locale and ignore
+    // the one passed as parameter.
+
+    #if defined(SFML_SYSTEM_WINDOWS) &&                       /* if Windows ... */                          \
+       (defined(__GLIBCPP__) || defined (__GLIBCXX__)) &&     /* ... and standard library is glibc++ ... */ \
+      !(defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)) /* ... and STLPort is not used on top of it */
+
+        (void)locale; // to avoid warnings
+
+        char character = 0;
+        if (wctomb(&character, static_cast<wchar_t>(codepoint)) >= 0)
+            *output++ = character;
+        else if (replacement)
+            *output++ = replacement;
+
+        return output;
+
+    #else
+
+        // Get the facet of the locale which deals with character conversion
+        const std::ctype<wchar_t>& facet = std::use_facet< std::ctype<wchar_t> >(locale);
+
+        // Use the facet to convert each character of the input string
+        *output++ = facet.narrow(static_cast<wchar_t>(codepoint), replacement);
+
+        return output;
+
+    #endif
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename Out>
+Out Utf<32>::encodeWide(Uint32 codepoint, Out output, wchar_t replacement)
+{
+    // The encoding of wide characters is not well defined and is left to the system;
+    // however we can safely assume that it is UCS-2 on Windows and
+    // UCS-4 on Unix systems.
+    // For UCS-2 we need to check if the source characters fits in (UCS-2 is a subset of UCS-4).
+    // For UCS-4 we can do a direct copy (UCS-4 *is* UTF-32).
+
+    switch (sizeof(wchar_t))
+    {
+        case 4:
+        {
+            *output++ = static_cast<wchar_t>(codepoint);
+            break;
+        }
+
+        default:
+        {
+            if ((codepoint <= 0xFFFF) && ((codepoint < 0xD800) || (codepoint > 0xDFFF)))
+            {
+                *output++ = static_cast<wchar_t>(codepoint);
+            }
+            else if (replacement)
+            {
+                *output++ = replacement;
+            }
+            break;
+        }
+    }
+
+    return output;
+}

--- a/libs/include/SFML/System/Vector2.hpp
+++ b/libs/include/SFML/System/Vector2.hpp
@@ -1,0 +1,301 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_VECTOR2_HPP
+#define SFML_VECTOR2_HPP
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Utility template class for manipulating
+///        2-dimensional vectors
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+class Vector2
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates a Vector2(0, 0).
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vector from its coordinates
+    ///
+    /// \param X X coordinate
+    /// \param Y Y coordinate
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2(T X, T Y);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vector from another type of vector
+    ///
+    /// This constructor doesn't replace the copy constructor,
+    /// it's called only when U != T.
+    /// A call to this constructor will fail to compile if U
+    /// is not convertible to T.
+    ///
+    /// \param vector Vector to convert
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename U>
+    explicit Vector2(const Vector2<U>& vector);
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    T x; ///< X coordinate of the vector
+    T y; ///< Y coordinate of the vector
+};
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of unary operator -
+///
+/// \param right Vector to negate
+///
+/// \return Memberwise opposite of the vector
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T> operator -(const Vector2<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator +=
+///
+/// This operator performs a memberwise addition of both vectors,
+/// and assigns the result to \a left.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator -=
+///
+/// This operator performs a memberwise subtraction of both vectors,
+/// and assigns the result to \a left.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T>& operator -=(Vector2<T>& left, const Vector2<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator +
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return Memberwise addition of both vectors
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T> operator +(const Vector2<T>& left, const Vector2<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator -
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return Memberwise subtraction of both vectors
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T> operator -(const Vector2<T>& left, const Vector2<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator *
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a scalar value)
+///
+/// \return Memberwise multiplication by \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T> operator *(const Vector2<T>& left, T right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator *
+///
+/// \param left  Left operand (a scalar value)
+/// \param right Right operand (a vector)
+///
+/// \return Memberwise multiplication by \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T> operator *(T left, const Vector2<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator *=
+///
+/// This operator performs a memberwise multiplication by \a right,
+/// and assigns the result to \a left.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a scalar value)
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T>& operator *=(Vector2<T>& left, T right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator /
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a scalar value)
+///
+/// \return Memberwise division by \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T> operator /(const Vector2<T>& left, T right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator /=
+///
+/// This operator performs a memberwise division by \a right,
+/// and assigns the result to \a left.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a scalar value)
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector2<T>& operator /=(Vector2<T>& left, T right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator ==
+///
+/// This operator compares strict equality between two vectors.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return True if \a left is equal to \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+bool operator ==(const Vector2<T>& left, const Vector2<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector2
+/// \brief Overload of binary operator !=
+///
+/// This operator compares strict difference between two vectors.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return True if \a left is not equal to \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+bool operator !=(const Vector2<T>& left, const Vector2<T>& right);
+
+#include <SFML/System/Vector2.inl>
+
+// Define the most common types
+typedef Vector2<int>          Vector2i;
+typedef Vector2<unsigned int> Vector2u;
+typedef Vector2<float>        Vector2f;
+
+} // namespace sf
+
+
+#endif // SFML_VECTOR2_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Vector2
+/// \ingroup system
+///
+/// sf::Vector2 is a simple class that defines a mathematical
+/// vector with two coordinates (x and y). It can be used to
+/// represent anything that has two dimensions: a size, a point,
+/// a velocity, etc.
+///
+/// The template parameter T is the type of the coordinates. It
+/// can be any type that supports arithmetic operations (+, -, /, *)
+/// and comparisons (==, !=), for example int or float.
+///
+/// You generally don't have to care about the templated form (sf::Vector2<T>),
+/// the most common specializations have special typedefs:
+/// \li sf::Vector2<float> is sf::Vector2f
+/// \li sf::Vector2<int> is sf::Vector2i
+/// \li sf::Vector2<unsigned int> is sf::Vector2u
+///
+/// The sf::Vector2 class has a small and simple interface, its x and y members
+/// can be accessed directly (there are no accessors like setX(), getX()) and it
+/// contains no mathematical function like dot product, cross product, length, etc.
+///
+/// Usage example:
+/// \code
+/// sf::Vector2f v1(16.5f, 24.f);
+/// v1.x = 18.2f;
+/// float y = v1.y;
+///
+/// sf::Vector2f v2 = v1 * 5.f;
+/// sf::Vector2f v3;
+/// v3 = v1 + v2;
+///
+/// bool different = (v2 != v3);
+/// \endcode
+///
+/// Note: for 3-dimensional vectors, see sf::Vector3.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Vector2.inl
+++ b/libs/include/SFML/System/Vector2.inl
@@ -1,0 +1,161 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T>::Vector2() :
+x(0),
+y(0)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T>::Vector2(T X, T Y) :
+x(X),
+y(Y)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+template <typename U>
+inline Vector2<T>::Vector2(const Vector2<U>& vector) :
+x(static_cast<T>(vector.x)),
+y(static_cast<T>(vector.y))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T> operator -(const Vector2<T>& right)
+{
+    return Vector2<T>(-right.x, -right.y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T>& operator +=(Vector2<T>& left, const Vector2<T>& right)
+{
+    left.x += right.x;
+    left.y += right.y;
+
+    return left;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T>& operator -=(Vector2<T>& left, const Vector2<T>& right)
+{
+    left.x -= right.x;
+    left.y -= right.y;
+
+    return left;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T> operator +(const Vector2<T>& left, const Vector2<T>& right)
+{
+    return Vector2<T>(left.x + right.x, left.y + right.y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T> operator -(const Vector2<T>& left, const Vector2<T>& right)
+{
+    return Vector2<T>(left.x - right.x, left.y - right.y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T> operator *(const Vector2<T>& left, T right)
+{
+    return Vector2<T>(left.x * right, left.y * right);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T> operator *(T left, const Vector2<T>& right)
+{
+    return Vector2<T>(right.x * left, right.y * left);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T>& operator *=(Vector2<T>& left, T right)
+{
+    left.x *= right;
+    left.y *= right;
+
+    return left;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T> operator /(const Vector2<T>& left, T right)
+{
+    return Vector2<T>(left.x / right, left.y / right);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector2<T>& operator /=(Vector2<T>& left, T right)
+{
+    left.x /= right;
+    left.y /= right;
+
+    return left;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline bool operator ==(const Vector2<T>& left, const Vector2<T>& right)
+{
+    return (left.x == right.x) && (left.y == right.y);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline bool operator !=(const Vector2<T>& left, const Vector2<T>& right)
+{
+    return (left.x != right.x) || (left.y != right.y);
+}

--- a/libs/include/SFML/System/Vector3.hpp
+++ b/libs/include/SFML/System/Vector3.hpp
@@ -1,0 +1,302 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_VECTOR3_HPP
+#define SFML_VECTOR3_HPP
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Utility template class for manipulating
+///        3-dimensional vectors
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+class Vector3
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// Creates a Vector3(0, 0, 0).
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector3();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vector from its coordinates
+    ///
+    /// \param X X coordinate
+    /// \param Y Y coordinate
+    /// \param Z Z coordinate
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector3(T X, T Y, T Z);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the vector from another type of vector
+    ///
+    /// This constructor doesn't replace the copy constructor,
+    /// it's called only when U != T.
+    /// A call to this constructor will fail to compile if U
+    /// is not convertible to T.
+    ///
+    /// \param vector Vector to convert
+    ///
+    ////////////////////////////////////////////////////////////
+    template <typename U>
+    explicit Vector3(const Vector3<U>& vector);
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    T x; ///< X coordinate of the vector
+    T y; ///< Y coordinate of the vector
+    T z; ///< Z coordinate of the vector
+};
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of unary operator -
+///
+/// \param left Vector to negate
+///
+/// \return Memberwise opposite of the vector
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T> operator -(const Vector3<T>& left);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator +=
+///
+/// This operator performs a memberwise addition of both vectors,
+/// and assigns the result to \a left.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T>& operator +=(Vector3<T>& left, const Vector3<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator -=
+///
+/// This operator performs a memberwise subtraction of both vectors,
+/// and assigns the result to \a left.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T>& operator -=(Vector3<T>& left, const Vector3<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator +
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return Memberwise addition of both vectors
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T> operator +(const Vector3<T>& left, const Vector3<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator -
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return Memberwise subtraction of both vectors
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T> operator -(const Vector3<T>& left, const Vector3<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator *
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a scalar value)
+///
+/// \return Memberwise multiplication by \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T> operator *(const Vector3<T>& left, T right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator *
+///
+/// \param left  Left operand (a scalar value)
+/// \param right Right operand (a vector)
+///
+/// \return Memberwise multiplication by \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T> operator *(T left, const Vector3<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator *=
+///
+/// This operator performs a memberwise multiplication by \a right,
+/// and assigns the result to \a left.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a scalar value)
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T>& operator *=(Vector3<T>& left, T right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator /
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a scalar value)
+///
+/// \return Memberwise division by \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T> operator /(const Vector3<T>& left, T right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator /=
+///
+/// This operator performs a memberwise division by \a right,
+/// and assigns the result to \a left.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a scalar value)
+///
+/// \return Reference to \a left
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+Vector3<T>& operator /=(Vector3<T>& left, T right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator ==
+///
+/// This operator compares strict equality between two vectors.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return True if \a left is equal to \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+bool operator ==(const Vector3<T>& left, const Vector3<T>& right);
+
+////////////////////////////////////////////////////////////
+/// \relates Vector3
+/// \brief Overload of binary operator !=
+///
+/// This operator compares strict difference between two vectors.
+///
+/// \param left  Left operand (a vector)
+/// \param right Right operand (a vector)
+///
+/// \return True if \a left is not equal to \a right
+///
+////////////////////////////////////////////////////////////
+template <typename T>
+bool operator !=(const Vector3<T>& left, const Vector3<T>& right);
+
+#include <SFML/System/Vector3.inl>
+
+// Define the most common types
+typedef Vector3<int>   Vector3i;
+typedef Vector3<float> Vector3f;
+
+} // namespace sf
+
+
+#endif // SFML_VECTOR3_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Vector3
+/// \ingroup system
+///
+/// sf::Vector3 is a simple class that defines a mathematical
+/// vector with three coordinates (x, y and z). It can be used to
+/// represent anything that has three dimensions: a size, a point,
+/// a velocity, etc.
+///
+/// The template parameter T is the type of the coordinates. It
+/// can be any type that supports arithmetic operations (+, -, /, *)
+/// and comparisons (==, !=), for example int or float.
+///
+/// You generally don't have to care about the templated form (sf::Vector3<T>),
+/// the most common specializations have special typedefs:
+/// \li sf::Vector3<float> is sf::Vector3f
+/// \li sf::Vector3<int> is sf::Vector3i
+///
+/// The sf::Vector3 class has a small and simple interface, its x and y members
+/// can be accessed directly (there are no accessors like setX(), getX()) and it
+/// contains no mathematical function like dot product, cross product, length, etc.
+///
+/// Usage example:
+/// \code
+/// sf::Vector3f v1(16.5f, 24.f, -8.2f);
+/// v1.x = 18.2f;
+/// float y = v1.y;
+/// float z = v1.z;
+///
+/// sf::Vector3f v2 = v1 * 5.f;
+/// sf::Vector3f v3;
+/// v3 = v1 + v2;
+///
+/// bool different = (v2 != v3);
+/// \endcode
+///
+/// Note: for 2-dimensional vectors, see sf::Vector2.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/System/Vector3.inl
+++ b/libs/include/SFML/System/Vector3.inl
@@ -1,0 +1,168 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T>::Vector3() :
+x(0),
+y(0),
+z(0)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T>::Vector3(T X, T Y, T Z) :
+x(X),
+y(Y),
+z(Z)
+{
+
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+template <typename U>
+inline Vector3<T>::Vector3(const Vector3<U>& vector) :
+x(static_cast<T>(vector.x)),
+y(static_cast<T>(vector.y)),
+z(static_cast<T>(vector.z))
+{
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T> operator -(const Vector3<T>& left)
+{
+    return Vector3<T>(-left.x, -left.y, -left.z);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T>& operator +=(Vector3<T>& left, const Vector3<T>& right)
+{
+    left.x += right.x;
+    left.y += right.y;
+    left.z += right.z;
+
+    return left;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T>& operator -=(Vector3<T>& left, const Vector3<T>& right)
+{
+    left.x -= right.x;
+    left.y -= right.y;
+    left.z -= right.z;
+
+    return left;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T> operator +(const Vector3<T>& left, const Vector3<T>& right)
+{
+    return Vector3<T>(left.x + right.x, left.y + right.y, left.z + right.z);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T> operator -(const Vector3<T>& left, const Vector3<T>& right)
+{
+    return Vector3<T>(left.x - right.x, left.y - right.y, left.z - right.z);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T> operator *(const Vector3<T>& left, T right)
+{
+    return Vector3<T>(left.x * right, left.y * right, left.z * right);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T> operator *(T left, const Vector3<T>& right)
+{
+    return Vector3<T>(right.x * left, right.y * left, right.z * left);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T>& operator *=(Vector3<T>& left, T right)
+{
+    left.x *= right;
+    left.y *= right;
+    left.z *= right;
+
+    return left;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T> operator /(const Vector3<T>& left, T right)
+{
+    return Vector3<T>(left.x / right, left.y / right, left.z / right);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline Vector3<T>& operator /=(Vector3<T>& left, T right)
+{
+    left.x /= right;
+    left.y /= right;
+    left.z /= right;
+
+    return left;
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline bool operator ==(const Vector3<T>& left, const Vector3<T>& right)
+{
+    return (left.x == right.x) && (left.y == right.y) && (left.z == right.z);
+}
+
+
+////////////////////////////////////////////////////////////
+template <typename T>
+inline bool operator !=(const Vector3<T>& left, const Vector3<T>& right)
+{
+    return (left.x != right.x) || (left.y != right.y) || (left.z != right.z);
+}

--- a/libs/include/SFML/Window.hpp
+++ b/libs/include/SFML/Window.hpp
@@ -1,0 +1,58 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SFML_WINDOW_HPP
+#define SFML_SFML_WINDOW_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+
+#include <SFML/System.hpp>
+#include <SFML/Window/Clipboard.hpp>
+#include <SFML/Window/Context.hpp>
+#include <SFML/Window/ContextSettings.hpp>
+#include <SFML/Window/Cursor.hpp>
+#include <SFML/Window/Event.hpp>
+#include <SFML/Window/Joystick.hpp>
+#include <SFML/Window/Keyboard.hpp>
+#include <SFML/Window/Mouse.hpp>
+#include <SFML/Window/Sensor.hpp>
+#include <SFML/Window/Touch.hpp>
+#include <SFML/Window/VideoMode.hpp>
+#include <SFML/Window/Window.hpp>
+#include <SFML/Window/WindowHandle.hpp>
+#include <SFML/Window/WindowStyle.hpp>
+
+
+
+#endif // SFML_SFML_WINDOW_HPP
+
+////////////////////////////////////////////////////////////
+/// \defgroup window Window module
+///
+/// Provides OpenGL-based windows, and abstractions for
+/// events and input handling.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Clipboard.hpp
+++ b/libs/include/SFML/Window/Clipboard.hpp
@@ -1,0 +1,119 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CLIPBOARD_HPP
+#define SFML_CLIPBOARD_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <SFML/System/String.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Give access to the system clipboard
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Clipboard
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the content of the clipboard as string data
+    ///
+    /// This function returns the content of the clipboard
+    /// as a string. If the clipboard does not contain string
+    /// it returns an empty sf::String object.
+    ///
+    /// \return Clipboard contents as sf::String object
+    ///
+    ////////////////////////////////////////////////////////////
+    static String getString();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the content of the clipboard as string data
+    ///
+    /// This function sets the content of the clipboard as a
+    /// string.
+    ///
+    /// \warning Due to limitations on some operating systems,
+    ///          setting the clipboard contents is only
+    ///          guaranteed to work if there is currently an
+    ///          open window for which events are being handled.
+    ///
+    /// \param text sf::String containing the data to be sent
+    /// to the clipboard
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setString(const String& text);
+};
+
+} // namespace sf
+
+
+#endif // SFML_CLIPBOARD_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Clipboard
+/// \ingroup window
+///
+/// sf::Clipboard provides an interface for getting and
+/// setting the contents of the system clipboard.
+///
+/// It is important to note that due to limitations on some
+/// operating systems, setting the clipboard contents is
+/// only guaranteed to work if there is currently an open
+/// window for which events are being handled.
+///
+/// Usage example:
+/// \code
+/// // get the clipboard content as a string
+/// sf::String string = sf::Clipboard::getString();
+///
+/// // or use it in the event loop
+/// sf::Event event;
+/// while(window.pollEvent(event))
+/// {
+///     if(event.type == sf::Event::Closed)
+///         window.close();
+///     if(event.type == sf::Event::KeyPressed)
+///     {
+///         // Using Ctrl + V to paste a string into SFML
+///         if(event.key.control && event.key.code == sf::Keyboard::V)
+///             string = sf::Clipboard::getString();
+///
+///         // Using Ctrl + C to copy a string out of SFML
+///         if(event.key.control && event.key.code == sf::Keyboard::C)
+///             sf::Clipboard::setString("Hello World!");
+///     }
+/// }
+/// \endcode
+///
+/// \see sf::String, sf::Event
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Context.hpp
+++ b/libs/include/SFML/Window/Context.hpp
@@ -1,0 +1,195 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CONTEXT_HPP
+#define SFML_CONTEXT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <SFML/Window/GlResource.hpp>
+#include <SFML/Window/ContextSettings.hpp>
+#include <SFML/System/NonCopyable.hpp>
+
+
+namespace sf
+{
+namespace priv
+{
+    class GlContext;
+}
+
+typedef void (*GlFunctionPointer)();
+
+////////////////////////////////////////////////////////////
+/// \brief Class holding a valid drawing context
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Context : GlResource, NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// The constructor creates and activates the context
+    ///
+    ////////////////////////////////////////////////////////////
+    Context();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// The destructor deactivates and destroys the context
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Context();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Activate or deactivate explicitly the context
+    ///
+    /// \param active True to activate, false to deactivate
+    ///
+    /// \return True on success, false on failure
+    ///
+    ////////////////////////////////////////////////////////////
+    bool setActive(bool active);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the settings of the context
+    ///
+    /// Note that these settings may be different than the ones
+    /// passed to the constructor; they are indeed adjusted if the
+    /// original settings are not directly supported by the system.
+    ///
+    /// \return Structure containing the settings
+    ///
+    ////////////////////////////////////////////////////////////
+    const ContextSettings& getSettings() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check whether a given OpenGL extension is available
+    ///
+    /// \param name Name of the extension to check for
+    ///
+    /// \return True if available, false if unavailable
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isExtensionAvailable(const char* name);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the address of an OpenGL function
+    ///
+    /// \param name Name of the function to get the address of
+    ///
+    /// \return Address of the OpenGL function, 0 on failure
+    ///
+    ////////////////////////////////////////////////////////////
+    static GlFunctionPointer getFunction(const char* name);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the currently active context
+    ///
+    /// This function will only return sf::Context objects.
+    /// Contexts created e.g. by RenderTargets or for internal
+    /// use will not be returned by this function.
+    ///
+    /// \return The currently active context or NULL if none is active
+    ///
+    ////////////////////////////////////////////////////////////
+    static const Context* getActiveContext();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the currently active context's ID
+    ///
+    /// The context ID is used to identify contexts when
+    /// managing unshareable OpenGL resources.
+    ///
+    /// \return The active context's ID or 0 if no context is currently active
+    ///
+    ////////////////////////////////////////////////////////////
+    static Uint64 getActiveContextId();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a in-memory context
+    ///
+    /// This constructor is for internal use, you don't need
+    /// to bother with it.
+    ///
+    /// \param settings Creation parameters
+    /// \param width    Back buffer width
+    /// \param height   Back buffer height
+    ///
+    ////////////////////////////////////////////////////////////
+    Context(const ContextSettings& settings, unsigned int width, unsigned int height);
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    priv::GlContext* m_context; ///< Internal OpenGL context
+};
+
+} // namespace sf
+
+
+#endif // SFML_CONTEXT_HPP
+
+////////////////////////////////////////////////////////////
+/// \class sf::Context
+/// \ingroup window
+///
+/// If you need to make OpenGL calls without having an
+/// active window (like in a thread), you can use an
+/// instance of this class to get a valid context.
+///
+/// Having a valid context is necessary for *every* OpenGL call.
+///
+/// Note that a context is only active in its current thread,
+/// if you create a new thread it will have no valid context
+/// by default.
+///
+/// To use a sf::Context instance, just construct it and let it
+/// live as long as you need a valid context. No explicit activation
+/// is needed, all it has to do is to exist. Its destructor
+/// will take care of deactivating and freeing all the attached
+/// resources.
+///
+/// Usage example:
+/// \code
+/// void threadFunction(void*)
+/// {
+///    sf::Context context;
+///    // from now on, you have a valid context
+///
+///    // you can make OpenGL calls
+///    glClear(GL_DEPTH_BUFFER_BIT);
+/// }
+/// // the context is automatically deactivated and destroyed
+/// // by the sf::Context destructor
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/ContextSettings.hpp
+++ b/libs/include/SFML/Window/ContextSettings.hpp
@@ -1,0 +1,149 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CONTEXTSETTINGS_HPP
+#define SFML_CONTEXTSETTINGS_HPP
+
+#include <SFML/Config.hpp>
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Structure defining the settings of the OpenGL
+///        context attached to a window
+///
+////////////////////////////////////////////////////////////
+struct ContextSettings
+{
+    ////////////////////////////////////////////////////////////
+    /// \brief Enumeration of the context attribute flags
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Attribute
+    {
+        Default = 0,      ///< Non-debug, compatibility context (this and the core attribute are mutually exclusive)
+        Core    = 1 << 0, ///< Core attribute
+        Debug   = 1 << 2  ///< Debug attribute
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// \param depth        Depth buffer bits
+    /// \param stencil      Stencil buffer bits
+    /// \param antialiasing Antialiasing level
+    /// \param major        Major number of the context version
+    /// \param minor        Minor number of the context version
+    /// \param attributes   Attribute flags of the context
+    /// \param sRgb         sRGB capable framebuffer
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit ContextSettings(unsigned int depth = 0, unsigned int stencil = 0, unsigned int antialiasing = 0, unsigned int major = 1, unsigned int minor = 1, unsigned int attributes = Default, bool sRgb = false) :
+    depthBits        (depth),
+    stencilBits      (stencil),
+    antialiasingLevel(antialiasing),
+    majorVersion     (major),
+    minorVersion     (minor),
+    attributeFlags   (attributes),
+    sRgbCapable      (sRgb)
+    {
+    }
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    unsigned int depthBits;         ///< Bits of the depth buffer
+    unsigned int stencilBits;       ///< Bits of the stencil buffer
+    unsigned int antialiasingLevel; ///< Level of antialiasing
+    unsigned int majorVersion;      ///< Major number of the context version to create
+    unsigned int minorVersion;      ///< Minor number of the context version to create
+    Uint32       attributeFlags;    ///< The attribute flags to create the context with
+    bool         sRgbCapable;       ///< Whether the context framebuffer is sRGB capable
+};
+
+} // namespace sf
+
+
+#endif // SFML_CONTEXTSETTINGS_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::ContextSettings
+/// \ingroup window
+///
+/// ContextSettings allows to define several advanced settings
+/// of the OpenGL context attached to a window. All these
+/// settings with the exception of the compatibility flag
+/// and anti-aliasing level have no impact on the regular
+/// SFML rendering (graphics module), so you may need to use
+/// this structure only if you're using SFML as a windowing
+/// system for custom OpenGL rendering.
+///
+/// The depthBits and stencilBits members define the number
+/// of bits per pixel requested for the (respectively) depth
+/// and stencil buffers.
+///
+/// antialiasingLevel represents the requested number of
+/// multisampling levels for anti-aliasing.
+///
+/// majorVersion and minorVersion define the version of the
+/// OpenGL context that you want. Only versions greater or
+/// equal to 3.0 are relevant; versions lesser than 3.0 are
+/// all handled the same way (i.e. you can use any version
+/// < 3.0 if you don't want an OpenGL 3 context).
+///
+/// When requesting a context with a version greater or equal
+/// to 3.2, you have the option of specifying whether the
+/// context should follow the core or compatibility profile
+/// of all newer (>= 3.2) OpenGL specifications. For versions
+/// 3.0 and 3.1 there is only the core profile. By default
+/// a compatibility context is created. You only need to specify
+/// the core flag if you want a core profile context to use with
+/// your own OpenGL rendering.
+/// <b>Warning: The graphics module will not function if you
+/// request a core profile context. Make sure the attributes are
+/// set to Default if you want to use the graphics module.</b>
+///
+/// Setting the debug attribute flag will request a context with
+/// additional debugging features enabled. Depending on the
+/// system, this might be required for advanced OpenGL debugging.
+/// OpenGL debugging is disabled by default.
+///
+/// <b>Special Note for OS X:</b>
+/// Apple only supports choosing between either a legacy context
+/// (OpenGL 2.1) or a core context (OpenGL version depends on the
+/// operating system version but is at least 3.2). Compatibility
+/// contexts are not supported. Further information is available on the
+/// <a href="https://developer.apple.com/opengl/capabilities/index.html">
+/// OpenGL Capabilities Tables</a> page. OS X also currently does
+/// not support debug contexts.
+///
+/// Please note that these values are only a hint.
+/// No failure will be reported if one or more of these values
+/// are not supported by the system; instead, SFML will try to
+/// find the closest valid match. You can then retrieve the
+/// settings that the window actually used to create its context,
+/// with Window::getSettings().
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Cursor.hpp
+++ b/libs/include/SFML/Window/Cursor.hpp
@@ -1,0 +1,222 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_CURSOR_HPP
+#define SFML_CURSOR_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/Vector2.hpp>
+
+namespace sf
+{
+namespace priv
+{
+    class CursorImpl;
+}
+
+////////////////////////////////////////////////////////////
+/// \brief Cursor defines the appearance of a system cursor
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Cursor : NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enumeration of the native system cursor types
+    ///
+    /// Refer to the following table to determine which cursor
+    /// is available on which platform.
+    ///
+    ///  Type                               | Linux | Mac OS X | Windows  |
+    /// ------------------------------------|:-----:|:--------:|:--------:|
+    ///  sf::Cursor::Arrow                  |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::ArrowWait              |  no   |    no    |   yes    |
+    ///  sf::Cursor::Wait                   |  yes  |    no    |   yes    |
+    ///  sf::Cursor::Text                   |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::Hand                   |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::SizeHorizontal         |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::SizeVertical           |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::SizeTopLeftBottomRight |  no   |    yes*  |   yes    |
+    ///  sf::Cursor::SizeBottomLeftTopRight |  no   |    yes*  |   yes    |
+    ///  sf::Cursor::SizeAll                |  yes  |    no    |   yes    |
+    ///  sf::Cursor::Cross                  |  yes  |    yes   |   yes    |
+    ///  sf::Cursor::Help                   |  yes  |    yes*  |   yes    |
+    ///  sf::Cursor::NotAllowed             |  yes  |    yes   |   yes    |
+    ///
+    ///  * These cursor types are undocumented so may not
+    ///    be available on all versions, but have been tested on 10.13
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Type
+    {
+        Arrow,                  ///< Arrow cursor (default)
+        ArrowWait,              ///< Busy arrow cursor
+        Wait,                   ///< Busy cursor
+        Text,                   ///< I-beam, cursor when hovering over a field allowing text entry
+        Hand,                   ///< Pointing hand cursor
+        SizeHorizontal,         ///< Horizontal double arrow cursor
+        SizeVertical,           ///< Vertical double arrow cursor
+        SizeTopLeftBottomRight, ///< Double arrow cursor going from top-left to bottom-right
+        SizeBottomLeftTopRight, ///< Double arrow cursor going from bottom-left to top-right
+        SizeAll,                ///< Combination of SizeHorizontal and SizeVertical
+        Cross,                  ///< Crosshair cursor
+        Help,                   ///< Help cursor
+        NotAllowed              ///< Action not allowed cursor
+    };
+
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor doesn't actually create the cursor;
+    /// initially the new instance is invalid and must not be
+    /// used until either loadFromPixels() or loadFromSystem()
+    /// is called and successfully created a cursor.
+    ///
+    ////////////////////////////////////////////////////////////
+    Cursor();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// This destructor releases the system resources
+    /// associated with this cursor, if any.
+    ///
+    ////////////////////////////////////////////////////////////
+    ~Cursor();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a cursor with the provided image
+    ///
+    /// \a pixels must be an array of \a width by \a height pixels
+    /// in 32-bit RGBA format. If not, this will cause undefined behavior.
+    ///
+    /// If \a pixels is null or either \a width or \a height are 0,
+    /// the current cursor is left unchanged and the function will
+    /// return false.
+    ///
+    /// In addition to specifying the pixel data, you can also
+    /// specify the location of the hotspot of the cursor. The
+    /// hotspot is the pixel coordinate within the cursor image
+    /// which will be located exactly where the mouse pointer
+    /// position is. Any mouse actions that are performed will
+    /// return the window/screen location of the hotspot.
+    ///
+    /// \warning On Unix, the pixels are mapped into a monochrome
+    ///          bitmap: pixels with an alpha channel to 0 are
+    ///          transparent, black if the RGB channel are close
+    ///          to zero, and white otherwise.
+    ///
+    /// \param pixels   Array of pixels of the image
+    /// \param size     Width and height of the image
+    /// \param hotspot  (x,y) location of the hotspot
+    /// \return true if the cursor was successfully loaded;
+    ///         false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromPixels(const Uint8* pixels, Vector2u size, Vector2u hotspot);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create a native system cursor
+    ///
+    /// Refer to the list of cursor available on each system
+    /// (see sf::Cursor::Type) to know whether a given cursor is
+    /// expected to load successfully or is not supported by
+    /// the operating system.
+    ///
+    /// \param type Native system cursor type
+    /// \return true if and only if the corresponding cursor is
+    ///         natively supported by the operating system;
+    ///         false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool loadFromSystem(Type type);
+
+private:
+
+    friend class Window;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get access to the underlying implementation
+    ///
+    /// This is primarily designed for sf::Window::setMouseCursor,
+    /// hence the friendship.
+    ///
+    /// \return a reference to the OS-specific implementation
+    ///
+    ////////////////////////////////////////////////////////////
+    const priv::CursorImpl& getImpl() const;
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    priv::CursorImpl* m_impl; ///< Platform-specific implementation of the cursor
+};
+
+} // namespace sf
+
+
+#endif // SFML_CURSOR_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Cursor
+/// \ingroup window
+///
+/// \warning Features related to Cursor are not supported on
+///          iOS and Android.
+///
+/// This class abstracts the operating system resources
+/// associated with either a native system cursor or a custom
+/// cursor.
+///
+/// After loading the cursor the graphical appearance
+/// with either loadFromPixels() or loadFromSystem(), the
+/// cursor can be changed with sf::Window::setMouseCursor().
+///
+/// The behaviour is undefined if the cursor is destroyed while
+/// in use by the window.
+///
+/// Usage example:
+/// \code
+/// sf::Window window;
+///
+/// // ... create window as usual ...
+///
+/// sf::Cursor cursor;
+/// if (cursor.loadFromSystem(sf::Cursor::Hand))
+///     window.setMouseCursor(cursor);
+/// \endcode
+///
+/// \see sf::Window::setMouseCursor
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Event.hpp
+++ b/libs/include/SFML/Window/Event.hpp
@@ -1,0 +1,284 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_EVENT_HPP
+#define SFML_EVENT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+#include <SFML/Window/Joystick.hpp>
+#include <SFML/Window/Keyboard.hpp>
+#include <SFML/Window/Mouse.hpp>
+#include <SFML/Window/Sensor.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Defines a system event and its parameters
+///
+////////////////////////////////////////////////////////////
+class Event
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Size events parameters (Resized)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct SizeEvent
+    {
+        unsigned int width;  ///< New width, in pixels
+        unsigned int height; ///< New height, in pixels
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Keyboard event parameters (KeyPressed, KeyReleased)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct KeyEvent
+    {
+        Keyboard::Key code;    ///< Code of the key that has been pressed
+        bool          alt;     ///< Is the Alt key pressed?
+        bool          control; ///< Is the Control key pressed?
+        bool          shift;   ///< Is the Shift key pressed?
+        bool          system;  ///< Is the System key pressed?
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Text event parameters (TextEntered)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct TextEvent
+    {
+        Uint32 unicode; ///< UTF-32 Unicode value of the character
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Mouse move event parameters (MouseMoved)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct MouseMoveEvent
+    {
+        int x; ///< X position of the mouse pointer, relative to the left of the owner window
+        int y; ///< Y position of the mouse pointer, relative to the top of the owner window
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Mouse buttons events parameters
+    ///        (MouseButtonPressed, MouseButtonReleased)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct MouseButtonEvent
+    {
+        Mouse::Button button; ///< Code of the button that has been pressed
+        int           x;      ///< X position of the mouse pointer, relative to the left of the owner window
+        int           y;      ///< Y position of the mouse pointer, relative to the top of the owner window
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Mouse wheel events parameters (MouseWheelMoved)
+    ///
+    /// \deprecated This event is deprecated and potentially inaccurate.
+    ///             Use MouseWheelScrollEvent instead.
+    ///
+    ////////////////////////////////////////////////////////////
+    struct MouseWheelEvent
+    {
+        int delta; ///< Number of ticks the wheel has moved (positive is up, negative is down)
+        int x;     ///< X position of the mouse pointer, relative to the left of the owner window
+        int y;     ///< Y position of the mouse pointer, relative to the top of the owner window
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Mouse wheel events parameters (MouseWheelScrolled)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct MouseWheelScrollEvent
+    {
+        Mouse::Wheel wheel; ///< Which wheel (for mice with multiple ones)
+        float        delta; ///< Wheel offset (positive is up/left, negative is down/right). High-precision mice may use non-integral offsets.
+        int          x;     ///< X position of the mouse pointer, relative to the left of the owner window
+        int          y;     ///< Y position of the mouse pointer, relative to the top of the owner window
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Joystick connection events parameters
+    ///        (JoystickConnected, JoystickDisconnected)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct JoystickConnectEvent
+    {
+        unsigned int joystickId; ///< Index of the joystick (in range [0 .. Joystick::Count - 1])
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Joystick axis move event parameters (JoystickMoved)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct JoystickMoveEvent
+    {
+        unsigned int   joystickId; ///< Index of the joystick (in range [0 .. Joystick::Count - 1])
+        Joystick::Axis axis;       ///< Axis on which the joystick moved
+        float          position;   ///< New position on the axis (in range [-100 .. 100])
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Joystick buttons events parameters
+    ///        (JoystickButtonPressed, JoystickButtonReleased)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct JoystickButtonEvent
+    {
+        unsigned int joystickId; ///< Index of the joystick (in range [0 .. Joystick::Count - 1])
+        unsigned int button;     ///< Index of the button that has been pressed (in range [0 .. Joystick::ButtonCount - 1])
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Touch events parameters (TouchBegan, TouchMoved, TouchEnded)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct TouchEvent
+    {
+        unsigned int finger; ///< Index of the finger in case of multi-touch events
+        int x;               ///< X position of the touch, relative to the left of the owner window
+        int y;               ///< Y position of the touch, relative to the top of the owner window
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sensor event parameters (SensorChanged)
+    ///
+    ////////////////////////////////////////////////////////////
+    struct SensorEvent
+    {
+        Sensor::Type type; ///< Type of the sensor
+        float x;           ///< Current value of the sensor on X axis
+        float y;           ///< Current value of the sensor on Y axis
+        float z;           ///< Current value of the sensor on Z axis
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enumeration of the different types of events
+    ///
+    ////////////////////////////////////////////////////////////
+    enum EventType
+    {
+        Closed,                 ///< The window requested to be closed (no data)
+        Resized,                ///< The window was resized (data in event.size)
+        LostFocus,              ///< The window lost the focus (no data)
+        GainedFocus,            ///< The window gained the focus (no data)
+        TextEntered,            ///< A character was entered (data in event.text)
+        KeyPressed,             ///< A key was pressed (data in event.key)
+        KeyReleased,            ///< A key was released (data in event.key)
+        MouseWheelMoved,        ///< The mouse wheel was scrolled (data in event.mouseWheel) (deprecated)
+        MouseWheelScrolled,     ///< The mouse wheel was scrolled (data in event.mouseWheelScroll)
+        MouseButtonPressed,     ///< A mouse button was pressed (data in event.mouseButton)
+        MouseButtonReleased,    ///< A mouse button was released (data in event.mouseButton)
+        MouseMoved,             ///< The mouse cursor moved (data in event.mouseMove)
+        MouseEntered,           ///< The mouse cursor entered the area of the window (no data)
+        MouseLeft,              ///< The mouse cursor left the area of the window (no data)
+        JoystickButtonPressed,  ///< A joystick button was pressed (data in event.joystickButton)
+        JoystickButtonReleased, ///< A joystick button was released (data in event.joystickButton)
+        JoystickMoved,          ///< The joystick moved along an axis (data in event.joystickMove)
+        JoystickConnected,      ///< A joystick was connected (data in event.joystickConnect)
+        JoystickDisconnected,   ///< A joystick was disconnected (data in event.joystickConnect)
+        TouchBegan,             ///< A touch event began (data in event.touch)
+        TouchMoved,             ///< A touch moved (data in event.touch)
+        TouchEnded,             ///< A touch event ended (data in event.touch)
+        SensorChanged,          ///< A sensor value changed (data in event.sensor)
+
+        Count                   ///< Keep last -- the total number of event types
+    };
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    EventType type; ///< Type of the event
+
+    union
+    {
+        SizeEvent             size;              ///< Size event parameters (Event::Resized)
+        KeyEvent              key;               ///< Key event parameters (Event::KeyPressed, Event::KeyReleased)
+        TextEvent             text;              ///< Text event parameters (Event::TextEntered)
+        MouseMoveEvent        mouseMove;         ///< Mouse move event parameters (Event::MouseMoved)
+        MouseButtonEvent      mouseButton;       ///< Mouse button event parameters (Event::MouseButtonPressed, Event::MouseButtonReleased)
+        MouseWheelEvent       mouseWheel;        ///< Mouse wheel event parameters (Event::MouseWheelMoved) (deprecated)
+        MouseWheelScrollEvent mouseWheelScroll;  ///< Mouse wheel event parameters (Event::MouseWheelScrolled)
+        JoystickMoveEvent     joystickMove;      ///< Joystick move event parameters (Event::JoystickMoved)
+        JoystickButtonEvent   joystickButton;    ///< Joystick button event parameters (Event::JoystickButtonPressed, Event::JoystickButtonReleased)
+        JoystickConnectEvent  joystickConnect;   ///< Joystick (dis)connect event parameters (Event::JoystickConnected, Event::JoystickDisconnected)
+        TouchEvent            touch;             ///< Touch events parameters (Event::TouchBegan, Event::TouchMoved, Event::TouchEnded)
+        SensorEvent           sensor;            ///< Sensor event parameters (Event::SensorChanged)
+    };
+};
+
+} // namespace sf
+
+
+#endif // SFML_EVENT_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Event
+/// \ingroup window
+///
+/// sf::Event holds all the informations about a system event
+/// that just happened. Events are retrieved using the
+/// sf::Window::pollEvent and sf::Window::waitEvent functions.
+///
+/// A sf::Event instance contains the type of the event
+/// (mouse moved, key pressed, window closed, ...) as well
+/// as the details about this particular event. Please note that
+/// the event parameters are defined in a union, which means that
+/// only the member matching the type of the event will be properly
+/// filled; all other members will have undefined values and must not
+/// be read if the type of the event doesn't match. For example,
+/// if you received a KeyPressed event, then you must read the
+/// event.key member, all other members such as event.mouseMove
+/// or event.text will have undefined values.
+///
+/// Usage example:
+/// \code
+/// sf::Event event;
+/// while (window.pollEvent(event))
+/// {
+///     // Request for closing the window
+///     if (event.type == sf::Event::Closed)
+///         window.close();
+///
+///     // The escape key was pressed
+///     if ((event.type == sf::Event::KeyPressed) && (event.key.code == sf::Keyboard::Escape))
+///         window.close();
+///
+///     // The window was resized
+///     if (event.type == sf::Event::Resized)
+///         doSomethingWithTheNewSize(event.size.width, event.size.height);
+///
+///     // etc ...
+/// }
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Export.hpp
+++ b/libs/include/SFML/Window/Export.hpp
@@ -1,0 +1,48 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_WINDOW_EXPORT_HPP
+#define SFML_WINDOW_EXPORT_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+
+////////////////////////////////////////////////////////////
+// Define portable import / export macros
+////////////////////////////////////////////////////////////
+#if defined(SFML_WINDOW_EXPORTS)
+
+    #define SFML_WINDOW_API SFML_API_EXPORT
+
+#else
+
+    #define SFML_WINDOW_API SFML_API_IMPORT
+
+#endif
+
+
+#endif // SFML_WINDOW_EXPORT_HPP

--- a/libs/include/SFML/Window/GlResource.hpp
+++ b/libs/include/SFML/Window/GlResource.hpp
@@ -1,0 +1,109 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_GLRESOURCE_HPP
+#define SFML_GLRESOURCE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <SFML/System/NonCopyable.hpp>
+
+
+namespace sf
+{
+
+class Context;
+
+typedef void(*ContextDestroyCallback)(void*);
+
+////////////////////////////////////////////////////////////
+/// \brief Base class for classes that require an OpenGL context
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API GlResource
+{
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    ////////////////////////////////////////////////////////////
+    GlResource();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    ////////////////////////////////////////////////////////////
+    ~GlResource();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Register a function to be called when a context is destroyed
+    ///
+    /// This is used for internal purposes in order to properly
+    /// clean up OpenGL resources that cannot be shared between
+    /// contexts.
+    ///
+    /// \param callback Function to be called when a context is destroyed
+    /// \param arg      Argument to pass when calling the function
+    ///
+    ////////////////////////////////////////////////////////////
+    static void registerContextDestroyCallback(ContextDestroyCallback callback, void* arg);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief RAII helper class to temporarily lock an available context for use
+    ///
+    ////////////////////////////////////////////////////////////
+    class SFML_WINDOW_API TransientContextLock : NonCopyable
+    {
+    public:
+        ////////////////////////////////////////////////////////////
+        /// \brief Default constructor
+        ///
+        ////////////////////////////////////////////////////////////
+        TransientContextLock();
+
+        ////////////////////////////////////////////////////////////
+        /// \brief Destructor
+        ///
+        ////////////////////////////////////////////////////////////
+        ~TransientContextLock();
+    };
+};
+
+} // namespace sf
+
+
+#endif // SFML_GLRESOURCE_HPP
+
+////////////////////////////////////////////////////////////
+/// \class sf::GlResource
+/// \ingroup window
+///
+/// This class is for internal use only, it must be the base
+/// of every class that requires a valid OpenGL context in
+/// order to work.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Joystick.hpp
+++ b/libs/include/SFML/Window/Joystick.hpp
@@ -1,0 +1,227 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_JOYSTICK_HPP
+#define SFML_JOYSTICK_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <SFML/System/String.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Give access to the real-time state of the joysticks
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Joystick
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Constants related to joysticks capabilities
+    ///
+    ////////////////////////////////////////////////////////////
+    enum
+    {
+        Count       = 8,  ///< Maximum number of supported joysticks
+        ButtonCount = 32, ///< Maximum number of supported buttons
+        AxisCount   = 8   ///< Maximum number of supported axes
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Axes supported by SFML joysticks
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Axis
+    {
+        X,    ///< The X axis
+        Y,    ///< The Y axis
+        Z,    ///< The Z axis
+        R,    ///< The R axis
+        U,    ///< The U axis
+        V,    ///< The V axis
+        PovX, ///< The X axis of the point-of-view hat
+        PovY  ///< The Y axis of the point-of-view hat
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Structure holding a joystick's identification
+    ///
+    ////////////////////////////////////////////////////////////
+    struct SFML_WINDOW_API Identification
+    {
+        Identification();
+
+        String       name;      ///< Name of the joystick
+        unsigned int vendorId;  ///< Manufacturer identifier
+        unsigned int productId; ///< Product identifier
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a joystick is connected
+    ///
+    /// \param joystick Index of the joystick to check
+    ///
+    /// \return True if the joystick is connected, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isConnected(unsigned int joystick);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Return the number of buttons supported by a joystick
+    ///
+    /// If the joystick is not connected, this function returns 0.
+    ///
+    /// \param joystick Index of the joystick
+    ///
+    /// \return Number of buttons supported by the joystick
+    ///
+    ////////////////////////////////////////////////////////////
+    static unsigned int getButtonCount(unsigned int joystick);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a joystick supports a given axis
+    ///
+    /// If the joystick is not connected, this function returns false.
+    ///
+    /// \param joystick Index of the joystick
+    /// \param axis     Axis to check
+    ///
+    /// \return True if the joystick supports the axis, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool hasAxis(unsigned int joystick, Axis axis);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a joystick button is pressed
+    ///
+    /// If the joystick is not connected, this function returns false.
+    ///
+    /// \param joystick Index of the joystick
+    /// \param button   Button to check
+    ///
+    /// \return True if the button is pressed, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isButtonPressed(unsigned int joystick, unsigned int button);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current position of a joystick axis
+    ///
+    /// If the joystick is not connected, this function returns 0.
+    ///
+    /// \param joystick Index of the joystick
+    /// \param axis     Axis to check
+    ///
+    /// \return Current position of the axis, in range [-100 .. 100]
+    ///
+    ////////////////////////////////////////////////////////////
+    static float getAxisPosition(unsigned int joystick, Axis axis);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the joystick information
+    ///
+    /// \param joystick Index of the joystick
+    ///
+    /// \return Structure containing joystick information.
+    ///
+    ////////////////////////////////////////////////////////////
+    static Identification getIdentification(unsigned int joystick);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Update the states of all joysticks
+    ///
+    /// This function is used internally by SFML, so you normally
+    /// don't have to call it explicitly. However, you may need to
+    /// call it if you have no window yet (or no window at all):
+    /// in this case the joystick states are not updated automatically.
+    ///
+    ////////////////////////////////////////////////////////////
+    static void update();
+};
+
+} // namespace sf
+
+
+#endif // SFML_JOYSTICK_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Joystick
+/// \ingroup window
+///
+/// sf::Joystick provides an interface to the state of the
+/// joysticks. It only contains static functions, so it's not
+/// meant to be instantiated. Instead, each joystick is identified
+/// by an index that is passed to the functions of this class.
+///
+/// This class allows users to query the state of joysticks at any
+/// time and directly, without having to deal with a window and
+/// its events. Compared to the JoystickMoved, JoystickButtonPressed
+/// and JoystickButtonReleased events, sf::Joystick can retrieve the
+/// state of axes and buttons of joysticks at any time
+/// (you don't need to store and update a boolean on your side
+/// in order to know if a button is pressed or released), and you
+/// always get the real state of joysticks, even if they are
+/// moved, pressed or released when your window is out of focus
+/// and no event is triggered.
+///
+/// SFML supports:
+/// \li 8 joysticks (sf::Joystick::Count)
+/// \li 32 buttons per joystick (sf::Joystick::ButtonCount)
+/// \li 8 axes per joystick (sf::Joystick::AxisCount)
+///
+/// Unlike the keyboard or mouse, the state of joysticks is sometimes
+/// not directly available (depending on the OS), therefore an update()
+/// function must be called in order to update the current state of
+/// joysticks. When you have a window with event handling, this is done
+/// automatically, you don't need to call anything. But if you have no
+/// window, or if you want to check joysticks state before creating one,
+/// you must call sf::Joystick::update explicitly.
+///
+/// Usage example:
+/// \code
+/// // Is joystick #0 connected?
+/// bool connected = sf::Joystick::isConnected(0);
+///
+/// // How many buttons does joystick #0 support?
+/// unsigned int buttons = sf::Joystick::getButtonCount(0);
+///
+/// // Does joystick #0 define a X axis?
+/// bool hasX = sf::Joystick::hasAxis(0, sf::Joystick::X);
+///
+/// // Is button #2 pressed on joystick #0?
+/// bool pressed = sf::Joystick::isButtonPressed(0, 2);
+///
+/// // What's the current position of the Y axis on joystick #0?
+/// float position = sf::Joystick::getAxisPosition(0, sf::Joystick::Y);
+/// \endcode
+///
+/// \see sf::Keyboard, sf::Mouse
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Keyboard.hpp
+++ b/libs/include/SFML/Window/Keyboard.hpp
@@ -1,0 +1,232 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_KEYBOARD_HPP
+#define SFML_KEYBOARD_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Give access to the real-time state of the keyboard
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Keyboard
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Key codes
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Key
+    {
+        Unknown = -1, ///< Unhandled key
+        A = 0,        ///< The A key
+        B,            ///< The B key
+        C,            ///< The C key
+        D,            ///< The D key
+        E,            ///< The E key
+        F,            ///< The F key
+        G,            ///< The G key
+        H,            ///< The H key
+        I,            ///< The I key
+        J,            ///< The J key
+        K,            ///< The K key
+        L,            ///< The L key
+        M,            ///< The M key
+        N,            ///< The N key
+        O,            ///< The O key
+        P,            ///< The P key
+        Q,            ///< The Q key
+        R,            ///< The R key
+        S,            ///< The S key
+        T,            ///< The T key
+        U,            ///< The U key
+        V,            ///< The V key
+        W,            ///< The W key
+        X,            ///< The X key
+        Y,            ///< The Y key
+        Z,            ///< The Z key
+        Num0,         ///< The 0 key
+        Num1,         ///< The 1 key
+        Num2,         ///< The 2 key
+        Num3,         ///< The 3 key
+        Num4,         ///< The 4 key
+        Num5,         ///< The 5 key
+        Num6,         ///< The 6 key
+        Num7,         ///< The 7 key
+        Num8,         ///< The 8 key
+        Num9,         ///< The 9 key
+        Escape,       ///< The Escape key
+        LControl,     ///< The left Control key
+        LShift,       ///< The left Shift key
+        LAlt,         ///< The left Alt key
+        LSystem,      ///< The left OS specific key: window (Windows and Linux), apple (MacOS X), ...
+        RControl,     ///< The right Control key
+        RShift,       ///< The right Shift key
+        RAlt,         ///< The right Alt key
+        RSystem,      ///< The right OS specific key: window (Windows and Linux), apple (MacOS X), ...
+        Menu,         ///< The Menu key
+        LBracket,     ///< The [ key
+        RBracket,     ///< The ] key
+        Semicolon,    ///< The ; key
+        Comma,        ///< The , key
+        Period,       ///< The . key
+        Quote,        ///< The ' key
+        Slash,        ///< The / key
+        Backslash,    ///< The \ key
+        Tilde,        ///< The ~ key
+        Equal,        ///< The = key
+        Hyphen,       ///< The - key (hyphen)
+        Space,        ///< The Space key
+        Enter,        ///< The Enter/Return keys
+        Backspace,    ///< The Backspace key
+        Tab,          ///< The Tabulation key
+        PageUp,       ///< The Page up key
+        PageDown,     ///< The Page down key
+        End,          ///< The End key
+        Home,         ///< The Home key
+        Insert,       ///< The Insert key
+        Delete,       ///< The Delete key
+        Add,          ///< The + key
+        Subtract,     ///< The - key (minus, usually from numpad)
+        Multiply,     ///< The * key
+        Divide,       ///< The / key
+        Left,         ///< Left arrow
+        Right,        ///< Right arrow
+        Up,           ///< Up arrow
+        Down,         ///< Down arrow
+        Numpad0,      ///< The numpad 0 key
+        Numpad1,      ///< The numpad 1 key
+        Numpad2,      ///< The numpad 2 key
+        Numpad3,      ///< The numpad 3 key
+        Numpad4,      ///< The numpad 4 key
+        Numpad5,      ///< The numpad 5 key
+        Numpad6,      ///< The numpad 6 key
+        Numpad7,      ///< The numpad 7 key
+        Numpad8,      ///< The numpad 8 key
+        Numpad9,      ///< The numpad 9 key
+        F1,           ///< The F1 key
+        F2,           ///< The F2 key
+        F3,           ///< The F3 key
+        F4,           ///< The F4 key
+        F5,           ///< The F5 key
+        F6,           ///< The F6 key
+        F7,           ///< The F7 key
+        F8,           ///< The F8 key
+        F9,           ///< The F9 key
+        F10,          ///< The F10 key
+        F11,          ///< The F11 key
+        F12,          ///< The F12 key
+        F13,          ///< The F13 key
+        F14,          ///< The F14 key
+        F15,          ///< The F15 key
+        Pause,        ///< The Pause key
+
+        KeyCount,     ///< Keep last -- the total number of keyboard keys
+
+        // Deprecated values:
+
+        Dash      = Hyphen,       ///< \deprecated Use Hyphen instead
+        BackSpace = Backspace,    ///< \deprecated Use Backspace instead
+        BackSlash = Backslash,    ///< \deprecated Use Backslash instead
+        SemiColon = Semicolon,    ///< \deprecated Use Semicolon instead
+        Return    = Enter         ///< \deprecated Use Enter instead
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a key is pressed
+    ///
+    /// \param key Key to check
+    ///
+    /// \return True if the key is pressed, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isKeyPressed(Key key);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the virtual keyboard
+    ///
+    /// Warning: the virtual keyboard is not supported on all
+    /// systems. It will typically be implemented on mobile OSes
+    /// (Android, iOS) but not on desktop OSes (Windows, Linux, ...).
+    ///
+    /// If the virtual keyboard is not available, this function does
+    /// nothing.
+    ///
+    /// \param visible True to show, false to hide
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setVirtualKeyboardVisible(bool visible);
+};
+
+} // namespace sf
+
+
+#endif // SFML_KEYBOARD_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Keyboard
+/// \ingroup window
+///
+/// sf::Keyboard provides an interface to the state of the
+/// keyboard. It only contains static functions (a single
+/// keyboard is assumed), so it's not meant to be instantiated.
+///
+/// This class allows users to query the keyboard state at any
+/// time and directly, without having to deal with a window and
+/// its events. Compared to the KeyPressed and KeyReleased events,
+/// sf::Keyboard can retrieve the state of a key at any time
+/// (you don't need to store and update a boolean on your side
+/// in order to know if a key is pressed or released), and you
+/// always get the real state of the keyboard, even if keys are
+/// pressed or released when your window is out of focus and no
+/// event is triggered.
+///
+/// Usage example:
+/// \code
+/// if (sf::Keyboard::isKeyPressed(sf::Keyboard::Left))
+/// {
+///     // move left...
+/// }
+/// else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Right))
+/// {
+///     // move right...
+/// }
+/// else if (sf::Keyboard::isKeyPressed(sf::Keyboard::Escape))
+/// {
+///     // quit...
+/// }
+/// \endcode
+///
+/// \see sf::Joystick, sf::Mouse, sf::Touch
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Mouse.hpp
+++ b/libs/include/SFML/Window/Mouse.hpp
@@ -1,0 +1,177 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_MOUSE_HPP
+#define SFML_MOUSE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <SFML/System/Vector2.hpp>
+
+
+namespace sf
+{
+class Window;
+
+////////////////////////////////////////////////////////////
+/// \brief Give access to the real-time state of the mouse
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Mouse
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Mouse buttons
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Button
+    {
+        Left,       ///< The left mouse button
+        Right,      ///< The right mouse button
+        Middle,     ///< The middle (wheel) mouse button
+        XButton1,   ///< The first extra mouse button
+        XButton2,   ///< The second extra mouse button
+
+        ButtonCount ///< Keep last -- the total number of mouse buttons
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Mouse wheels
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Wheel
+    {
+        VerticalWheel,  ///< The vertical mouse wheel
+        HorizontalWheel ///< The horizontal mouse wheel
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a mouse button is pressed
+    ///
+    /// \param button Button to check
+    ///
+    /// \return True if the button is pressed, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isButtonPressed(Button button);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current position of the mouse in desktop coordinates
+    ///
+    /// This function returns the global position of the mouse
+    /// cursor on the desktop.
+    ///
+    /// \return Current position of the mouse
+    ///
+    ////////////////////////////////////////////////////////////
+    static Vector2i getPosition();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current position of the mouse in window coordinates
+    ///
+    /// This function returns the current position of the mouse
+    /// cursor, relative to the given window.
+    ///
+    /// \param relativeTo Reference window
+    ///
+    /// \return Current position of the mouse
+    ///
+    ////////////////////////////////////////////////////////////
+    static Vector2i getPosition(const Window& relativeTo);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current position of the mouse in desktop coordinates
+    ///
+    /// This function sets the global position of the mouse
+    /// cursor on the desktop.
+    ///
+    /// \param position New position of the mouse
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setPosition(const Vector2i& position);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the current position of the mouse in window coordinates
+    ///
+    /// This function sets the current position of the mouse
+    /// cursor, relative to the given window.
+    ///
+    /// \param position New position of the mouse
+    /// \param relativeTo Reference window
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setPosition(const Vector2i& position, const Window& relativeTo);
+};
+
+} // namespace sf
+
+
+#endif // SFML_MOUSE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Mouse
+/// \ingroup window
+///
+/// sf::Mouse provides an interface to the state of the
+/// mouse. It only contains static functions (a single
+/// mouse is assumed), so it's not meant to be instantiated.
+///
+/// This class allows users to query the mouse state at any
+/// time and directly, without having to deal with a window and
+/// its events. Compared to the MouseMoved, MouseButtonPressed
+/// and MouseButtonReleased events, sf::Mouse can retrieve the
+/// state of the cursor and the buttons at any time
+/// (you don't need to store and update a boolean on your side
+/// in order to know if a button is pressed or released), and you
+/// always get the real state of the mouse, even if it is
+/// moved, pressed or released when your window is out of focus
+/// and no event is triggered.
+///
+/// The setPosition and getPosition functions can be used to change
+/// or retrieve the current position of the mouse pointer. There are
+/// two versions: one that operates in global coordinates (relative
+/// to the desktop) and one that operates in window coordinates
+/// (relative to a specific window).
+///
+/// Usage example:
+/// \code
+/// if (sf::Mouse::isButtonPressed(sf::Mouse::Left))
+/// {
+///     // left click...
+/// }
+///
+/// // get global mouse position
+/// sf::Vector2i position = sf::Mouse::getPosition();
+///
+/// // set mouse position relative to a window
+/// sf::Mouse::setPosition(sf::Vector2i(100, 200), window);
+/// \endcode
+///
+/// \see sf::Joystick, sf::Keyboard, sf::Touch
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Sensor.hpp
+++ b/libs/include/SFML/Window/Sensor.hpp
@@ -1,0 +1,150 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_SENSOR_HPP
+#define SFML_SENSOR_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <SFML/System/Vector3.hpp>
+#include <SFML/System/Time.hpp>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief Give access to the real-time state of the sensors
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Sensor
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Sensor type
+    ///
+    ////////////////////////////////////////////////////////////
+    enum Type
+    {
+        Accelerometer,    ///< Measures the raw acceleration (m/s^2)
+        Gyroscope,        ///< Measures the raw rotation rates (degrees/s)
+        Magnetometer,     ///< Measures the ambient magnetic field (micro-teslas)
+        Gravity,          ///< Measures the direction and intensity of gravity, independent of device acceleration (m/s^2)
+        UserAcceleration, ///< Measures the direction and intensity of device acceleration, independent of the gravity (m/s^2)
+        Orientation,      ///< Measures the absolute 3D orientation (degrees)
+
+        Count             ///< Keep last -- the total number of sensor types
+    };
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a sensor is available on the underlying platform
+    ///
+    /// \param sensor Sensor to check
+    ///
+    /// \return True if the sensor is available, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isAvailable(Type sensor);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable a sensor
+    ///
+    /// All sensors are disabled by default, to avoid consuming too
+    /// much battery power. Once a sensor is enabled, it starts
+    /// sending events of the corresponding type.
+    ///
+    /// This function does nothing if the sensor is unavailable.
+    ///
+    /// \param sensor  Sensor to enable
+    /// \param enabled True to enable, false to disable
+    ///
+    ////////////////////////////////////////////////////////////
+    static void setEnabled(Type sensor, bool enabled);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current sensor value
+    ///
+    /// \param sensor Sensor to read
+    ///
+    /// \return The current sensor value
+    ///
+    ////////////////////////////////////////////////////////////
+    static Vector3f getValue(Type sensor);
+};
+
+} // namespace sf
+
+
+#endif // SFML_SENSOR_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Sensor
+/// \ingroup window
+///
+/// sf::Sensor provides an interface to the state of the
+/// various sensors that a device provides. It only contains static
+/// functions, so it's not meant to be instantiated.
+///
+/// This class allows users to query the sensors values at any
+/// time and directly, without having to deal with a window and
+/// its events. Compared to the SensorChanged event, sf::Sensor
+/// can retrieve the state of a sensor at any time (you don't need to
+/// store and update its current value on your side).
+///
+/// Depending on the OS and hardware of the device (phone, tablet, ...),
+/// some sensor types may not be available. You should always check
+/// the availability of a sensor before trying to read it, with the
+/// sf::Sensor::isAvailable function.
+///
+/// You may wonder why some sensor types look so similar, for example
+/// Accelerometer and Gravity / UserAcceleration. The first one
+/// is the raw measurement of the acceleration, and takes into account
+/// both the earth gravity and the user movement. The others are
+/// more precise: they provide these components separately, which is
+/// usually more useful. In fact they are not direct sensors, they
+/// are computed internally based on the raw acceleration and other sensors.
+/// This is exactly the same for Gyroscope vs Orientation.
+///
+/// Because sensors consume a non-negligible amount of current, they are
+/// all disabled by default. You must call sf::Sensor::setEnabled for each
+/// sensor in which you are interested.
+///
+/// Usage example:
+/// \code
+/// if (sf::Sensor::isAvailable(sf::Sensor::Gravity))
+/// {
+///     // gravity sensor is available
+/// }
+///
+/// // enable the gravity sensor
+/// sf::Sensor::setEnabled(sf::Sensor::Gravity, true);
+///
+/// // get the current value of gravity
+/// sf::Vector3f gravity = sf::Sensor::getValue(sf::Sensor::Gravity);
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Touch.hpp
+++ b/libs/include/SFML/Window/Touch.hpp
@@ -1,0 +1,137 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_TOUCH_HPP
+#define SFML_TOUCH_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <SFML/System/Vector2.hpp>
+
+
+namespace sf
+{
+class Window;
+
+////////////////////////////////////////////////////////////
+/// \brief Give access to the real-time state of the touches
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Touch
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check if a touch event is currently down
+    ///
+    /// \param finger Finger index
+    ///
+    /// \return True if \a finger is currently touching the screen, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    static bool isDown(unsigned int finger);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current position of a touch in desktop coordinates
+    ///
+    /// This function returns the current touch position
+    /// in global (desktop) coordinates.
+    ///
+    /// \param finger Finger index
+    ///
+    /// \return Current position of \a finger, or undefined if it's not down
+    ///
+    ////////////////////////////////////////////////////////////
+    static Vector2i getPosition(unsigned int finger);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current position of a touch in window coordinates
+    ///
+    /// This function returns the current touch position
+    /// relative to the given window.
+    ///
+    /// \param finger Finger index
+    /// \param relativeTo Reference window
+    ///
+    /// \return Current position of \a finger, or undefined if it's not down
+    ///
+    ////////////////////////////////////////////////////////////
+    static Vector2i getPosition(unsigned int finger, const Window& relativeTo);
+};
+
+} // namespace sf
+
+
+#endif // SFML_TOUCH_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Touch
+/// \ingroup window
+///
+/// sf::Touch provides an interface to the state of the
+/// touches. It only contains static functions, so it's not
+/// meant to be instantiated.
+///
+/// This class allows users to query the touches state at any
+/// time and directly, without having to deal with a window and
+/// its events. Compared to the TouchBegan, TouchMoved
+/// and TouchEnded events, sf::Touch can retrieve the
+/// state of the touches at any time (you don't need to store and
+/// update a boolean on your side in order to know if a touch is down),
+/// and you always get the real state of the touches, even if they
+/// happen when your window is out of focus and no event is triggered.
+///
+/// The getPosition function can be used to retrieve the current
+/// position of a touch. There are two versions: one that operates
+/// in global coordinates (relative to the desktop) and one that
+/// operates in window coordinates (relative to a specific window).
+///
+/// Touches are identified by an index (the "finger"), so that in
+/// multi-touch events, individual touches can be tracked correctly.
+/// As long as a finger touches the screen, it will keep the same index
+/// even if other fingers start or stop touching the screen in the
+/// meantime. As a consequence, active touch indices may not always be
+/// sequential (i.e. touch number 0 may be released while touch number 1
+/// is still down).
+///
+/// Usage example:
+/// \code
+/// if (sf::Touch::isDown(0))
+/// {
+///     // touch 0 is down
+/// }
+///
+/// // get global position of touch 1
+/// sf::Vector2i globalPos = sf::Touch::getPosition(1);
+///
+/// // get position of touch 1 relative to a window
+/// sf::Vector2i relativePos = sf::Touch::getPosition(1, window);
+/// \endcode
+///
+/// \see sf::Joystick, sf::Keyboard, sf::Mouse
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/VideoMode.hpp
+++ b/libs/include/SFML/Window/VideoMode.hpp
@@ -1,0 +1,228 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_VIDEOMODE_HPP
+#define SFML_VIDEOMODE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/Export.hpp>
+#include <vector>
+
+
+namespace sf
+{
+////////////////////////////////////////////////////////////
+/// \brief VideoMode defines a video mode (width, height, bpp)
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API VideoMode
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructors initializes all members to 0.
+    ///
+    ////////////////////////////////////////////////////////////
+    VideoMode();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the video mode with its attributes
+    ///
+    /// \param modeWidth        Width in pixels
+    /// \param modeHeight       Height in pixels
+    /// \param modeBitsPerPixel Pixel depths in bits per pixel
+    ///
+    ////////////////////////////////////////////////////////////
+    VideoMode(unsigned int modeWidth, unsigned int modeHeight, unsigned int modeBitsPerPixel = 32);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the current desktop video mode
+    ///
+    /// \return Current desktop video mode
+    ///
+    ////////////////////////////////////////////////////////////
+    static VideoMode getDesktopMode();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Retrieve all the video modes supported in fullscreen mode
+    ///
+    /// When creating a fullscreen window, the video mode is restricted
+    /// to be compatible with what the graphics driver and monitor
+    /// support. This function returns the complete list of all video
+    /// modes that can be used in fullscreen mode.
+    /// The returned array is sorted from best to worst, so that
+    /// the first element will always give the best mode (higher
+    /// width, height and bits-per-pixel).
+    ///
+    /// \return Array containing all the supported fullscreen modes
+    ///
+    ////////////////////////////////////////////////////////////
+    static const std::vector<VideoMode>& getFullscreenModes();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the video mode is valid
+    ///
+    /// The validity of video modes is only relevant when using
+    /// fullscreen windows; otherwise any video mode can be used
+    /// with no restriction.
+    ///
+    /// \return True if the video mode is valid for fullscreen mode
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isValid() const;
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    unsigned int width;        ///< Video mode width, in pixels
+    unsigned int height;       ///< Video mode height, in pixels
+    unsigned int bitsPerPixel; ///< Video mode pixel depth, in bits per pixels
+};
+
+////////////////////////////////////////////////////////////
+/// \relates VideoMode
+/// \brief Overload of == operator to compare two video modes
+///
+/// \param left  Left operand (a video mode)
+/// \param right Right operand (a video mode)
+///
+/// \return True if modes are equal
+///
+////////////////////////////////////////////////////////////
+SFML_WINDOW_API bool operator ==(const VideoMode& left, const VideoMode& right);
+
+////////////////////////////////////////////////////////////
+/// \relates VideoMode
+/// \brief Overload of != operator to compare two video modes
+///
+/// \param left  Left operand (a video mode)
+/// \param right Right operand (a video mode)
+///
+/// \return True if modes are different
+///
+////////////////////////////////////////////////////////////
+SFML_WINDOW_API bool operator !=(const VideoMode& left, const VideoMode& right);
+
+////////////////////////////////////////////////////////////
+/// \relates VideoMode
+/// \brief Overload of < operator to compare video modes
+///
+/// \param left  Left operand (a video mode)
+/// \param right Right operand (a video mode)
+///
+/// \return True if \a left is lesser than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_WINDOW_API bool operator <(const VideoMode& left, const VideoMode& right);
+
+////////////////////////////////////////////////////////////
+/// \relates VideoMode
+/// \brief Overload of > operator to compare video modes
+///
+/// \param left  Left operand (a video mode)
+/// \param right Right operand (a video mode)
+///
+/// \return True if \a left is greater than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_WINDOW_API bool operator >(const VideoMode& left, const VideoMode& right);
+
+////////////////////////////////////////////////////////////
+/// \relates VideoMode
+/// \brief Overload of <= operator to compare video modes
+///
+/// \param left  Left operand (a video mode)
+/// \param right Right operand (a video mode)
+///
+/// \return True if \a left is lesser or equal than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_WINDOW_API bool operator <=(const VideoMode& left, const VideoMode& right);
+
+////////////////////////////////////////////////////////////
+/// \relates VideoMode
+/// \brief Overload of >= operator to compare video modes
+///
+/// \param left  Left operand (a video mode)
+/// \param right Right operand (a video mode)
+///
+/// \return True if \a left is greater or equal than \a right
+///
+////////////////////////////////////////////////////////////
+SFML_WINDOW_API bool operator >=(const VideoMode& left, const VideoMode& right);
+
+} // namespace sf
+
+
+#endif // SFML_VIDEOMODE_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::VideoMode
+/// \ingroup window
+///
+/// A video mode is defined by a width and a height (in pixels)
+/// and a depth (in bits per pixel). Video modes are used to
+/// setup windows (sf::Window) at creation time.
+///
+/// The main usage of video modes is for fullscreen mode:
+/// indeed you must use one of the valid video modes
+/// allowed by the OS (which are defined by what the monitor
+/// and the graphics card support), otherwise your window
+/// creation will just fail.
+///
+/// sf::VideoMode provides a static function for retrieving
+/// the list of all the video modes supported by the system:
+/// getFullscreenModes().
+///
+/// A custom video mode can also be checked directly for
+/// fullscreen compatibility with its isValid() function.
+///
+/// Additionally, sf::VideoMode provides a static function
+/// to get the mode currently used by the desktop: getDesktopMode().
+/// This allows to build windows with the same size or pixel
+/// depth as the current resolution.
+///
+/// Usage example:
+/// \code
+/// // Display the list of all the video modes available for fullscreen
+/// std::vector<sf::VideoMode> modes = sf::VideoMode::getFullscreenModes();
+/// for (std::size_t i = 0; i < modes.size(); ++i)
+/// {
+///     sf::VideoMode mode = modes[i];
+///     std::cout << "Mode #" << i << ": "
+///               << mode.width << "x" << mode.height << " - "
+///               << mode.bitsPerPixel << " bpp" << std::endl;
+/// }
+///
+/// // Create a window with the same pixel depth as the desktop
+/// sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
+/// window.create(sf::VideoMode(1024, 768, desktop.bitsPerPixel), "SFML window");
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/Window.hpp
+++ b/libs/include/SFML/Window/Window.hpp
@@ -1,0 +1,622 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_WINDOW_HPP
+#define SFML_WINDOW_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Window/ContextSettings.hpp>
+#include <SFML/Window/Cursor.hpp>
+#include <SFML/Window/Export.hpp>
+#include <SFML/Window/GlResource.hpp>
+#include <SFML/Window/VideoMode.hpp>
+#include <SFML/Window/WindowHandle.hpp>
+#include <SFML/Window/WindowStyle.hpp>
+#include <SFML/System/Clock.hpp>
+#include <SFML/System/NonCopyable.hpp>
+#include <SFML/System/String.hpp>
+#include <SFML/System/Vector2.hpp>
+
+
+namespace sf
+{
+namespace priv
+{
+    class GlContext;
+    class WindowImpl;
+}
+
+class Event;
+
+////////////////////////////////////////////////////////////
+/// \brief Window that serves as a target for OpenGL rendering
+///
+////////////////////////////////////////////////////////////
+class SFML_WINDOW_API Window : GlResource, NonCopyable
+{
+public:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Default constructor
+    ///
+    /// This constructor doesn't actually create the window,
+    /// use the other constructors or call create() to do so.
+    ///
+    ////////////////////////////////////////////////////////////
+    Window();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct a new window
+    ///
+    /// This constructor creates the window with the size and pixel
+    /// depth defined in \a mode. An optional style can be passed to
+    /// customize the look and behavior of the window (borders,
+    /// title bar, resizable, closable, ...). If \a style contains
+    /// Style::Fullscreen, then \a mode must be a valid video mode.
+    ///
+    /// The fourth parameter is an optional structure specifying
+    /// advanced OpenGL context settings such as antialiasing,
+    /// depth-buffer bits, etc.
+    ///
+    /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title    Title of the window
+    /// \param style    %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    Window(VideoMode mode, const String& title, Uint32 style = Style::Default, const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Construct the window from an existing control
+    ///
+    /// Use this constructor if you want to create an OpenGL
+    /// rendering area into an already existing control.
+    ///
+    /// The second parameter is an optional structure specifying
+    /// advanced OpenGL context settings such as antialiasing,
+    /// depth-buffer bits, etc.
+    ///
+    /// \param handle   Platform-specific handle of the control
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    explicit Window(WindowHandle handle, const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Destructor
+    ///
+    /// Closes the window and frees all the resources attached to it.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual ~Window();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create (or recreate) the window
+    ///
+    /// If the window was already created, it closes it first.
+    /// If \a style contains Style::Fullscreen, then \a mode
+    /// must be a valid video mode.
+    ///
+    /// The fourth parameter is an optional structure specifying
+    /// advanced OpenGL context settings such as antialiasing,
+    /// depth-buffer bits, etc.
+    ///
+    /// \param mode     Video mode to use (defines the width, height and depth of the rendering area of the window)
+    /// \param title    Title of the window
+    /// \param style    %Window style, a bitwise OR combination of sf::Style enumerators
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    void create(VideoMode mode, const String& title, Uint32 style = Style::Default, const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Create (or recreate) the window from an existing control
+    ///
+    /// Use this function if you want to create an OpenGL
+    /// rendering area into an already existing control.
+    /// If the window was already created, it closes it first.
+    ///
+    /// The second parameter is an optional structure specifying
+    /// advanced OpenGL context settings such as antialiasing,
+    /// depth-buffer bits, etc.
+    ///
+    /// \param handle   Platform-specific handle of the control
+    /// \param settings Additional settings for the underlying OpenGL context
+    ///
+    ////////////////////////////////////////////////////////////
+    void create(WindowHandle handle, const ContextSettings& settings = ContextSettings());
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Close the window and destroy all the attached resources
+    ///
+    /// After calling this function, the sf::Window instance remains
+    /// valid and you can call create() to recreate the window.
+    /// All other functions such as pollEvent() or display() will
+    /// still work (i.e. you don't have to test isOpen() every time),
+    /// and will have no effect on closed windows.
+    ///
+    ////////////////////////////////////////////////////////////
+    void close();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Tell whether or not the window is open
+    ///
+    /// This function returns whether or not the window exists.
+    /// Note that a hidden window (setVisible(false)) is open
+    /// (therefore this function would return true).
+    ///
+    /// \return True if the window is open, false if it has been closed
+    ///
+    ////////////////////////////////////////////////////////////
+    bool isOpen() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the settings of the OpenGL context of the window
+    ///
+    /// Note that these settings may be different from what was
+    /// passed to the constructor or the create() function,
+    /// if one or more settings were not supported. In this case,
+    /// SFML chose the closest match.
+    ///
+    /// \return Structure containing the OpenGL context settings
+    ///
+    ////////////////////////////////////////////////////////////
+    const ContextSettings& getSettings() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Pop the event on top of the event queue, if any, and return it
+    ///
+    /// This function is not blocking: if there's no pending event then
+    /// it will return false and leave \a event unmodified.
+    /// Note that more than one event may be present in the event queue,
+    /// thus you should always call this function in a loop
+    /// to make sure that you process every pending event.
+    /// \code
+    /// sf::Event event;
+    /// while (window.pollEvent(event))
+    /// {
+    ///    // process event...
+    /// }
+    /// \endcode
+    ///
+    /// \param event Event to be returned
+    ///
+    /// \return True if an event was returned, or false if the event queue was empty
+    ///
+    /// \see waitEvent
+    ///
+    ////////////////////////////////////////////////////////////
+    bool pollEvent(Event& event);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Wait for an event and return it
+    ///
+    /// This function is blocking: if there's no pending event then
+    /// it will wait until an event is received.
+    /// After this function returns (and no error occurred),
+    /// the \a event object is always valid and filled properly.
+    /// This function is typically used when you have a thread that
+    /// is dedicated to events handling: you want to make this thread
+    /// sleep as long as no new event is received.
+    /// \code
+    /// sf::Event event;
+    /// if (window.waitEvent(event))
+    /// {
+    ///    // process event...
+    /// }
+    /// \endcode
+    ///
+    /// \param event Event to be returned
+    ///
+    /// \return False if any error occurred
+    ///
+    /// \see pollEvent
+    ///
+    ////////////////////////////////////////////////////////////
+    bool waitEvent(Event& event);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the position of the window
+    ///
+    /// \return Position of the window, in pixels
+    ///
+    /// \see setPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2i getPosition() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the position of the window on screen
+    ///
+    /// This function only works for top-level windows
+    /// (i.e. it will be ignored for windows created from
+    /// the handle of a child window/control).
+    ///
+    /// \param position New position, in pixels
+    ///
+    /// \see getPosition
+    ///
+    ////////////////////////////////////////////////////////////
+    void setPosition(const Vector2i& position);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the size of the rendering region of the window
+    ///
+    /// The size doesn't include the titlebar and borders
+    /// of the window.
+    ///
+    /// \return Size in pixels
+    ///
+    /// \see setSize
+    ///
+    ////////////////////////////////////////////////////////////
+    Vector2u getSize() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the size of the rendering region of the window
+    ///
+    /// \param size New size, in pixels
+    ///
+    /// \see getSize
+    ///
+    ////////////////////////////////////////////////////////////
+    void setSize(const Vector2u& size);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the title of the window
+    ///
+    /// \param title New title
+    ///
+    /// \see setIcon
+    ///
+    ////////////////////////////////////////////////////////////
+    void setTitle(const String& title);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the window's icon
+    ///
+    /// \a pixels must be an array of \a width x \a height pixels
+    /// in 32-bits RGBA format.
+    ///
+    /// The OS default icon is used by default.
+    ///
+    /// \param width  Icon's width, in pixels
+    /// \param height Icon's height, in pixels
+    /// \param pixels Pointer to the array of pixels in memory. The
+    ///               pixels are copied, so you need not keep the
+    ///               source alive after calling this function.
+    ///
+    /// \see setTitle
+    ///
+    ////////////////////////////////////////////////////////////
+    void setIcon(unsigned int width, unsigned int height, const Uint8* pixels);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the window
+    ///
+    /// The window is shown by default.
+    ///
+    /// \param visible True to show the window, false to hide it
+    ///
+    ////////////////////////////////////////////////////////////
+    void setVisible(bool visible);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable vertical synchronization
+    ///
+    /// Activating vertical synchronization will limit the number
+    /// of frames displayed to the refresh rate of the monitor.
+    /// This can avoid some visual artifacts, and limit the framerate
+    /// to a good value (but not constant across different computers).
+    ///
+    /// Vertical synchronization is disabled by default.
+    ///
+    /// \param enabled True to enable v-sync, false to deactivate it
+    ///
+    ////////////////////////////////////////////////////////////
+    void setVerticalSyncEnabled(bool enabled);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Show or hide the mouse cursor
+    ///
+    /// The mouse cursor is visible by default.
+    ///
+    /// \param visible True to show the mouse cursor, false to hide it
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMouseCursorVisible(bool visible);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Grab or release the mouse cursor
+    ///
+    /// If set, grabs the mouse cursor inside this window's client
+    /// area so it may no longer be moved outside its bounds.
+    /// Note that grabbing is only active while the window has
+    /// focus.
+    ///
+    /// \param grabbed True to enable, false to disable
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMouseCursorGrabbed(bool grabbed);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Set the displayed cursor to a native system cursor
+    ///
+    /// Upon window creation, the arrow cursor is used by default.
+    ///
+    /// \warning The cursor must not be destroyed while in use by
+    ///          the window.
+    ///
+    /// \warning Features related to Cursor are not supported on
+    ///          iOS and Android.
+    ///
+    /// \param cursor Native system cursor type to display
+    ///
+    /// \see sf::Cursor::loadFromSystem
+    /// \see sf::Cursor::loadFromPixels
+    ///
+    ////////////////////////////////////////////////////////////
+    void setMouseCursor(const Cursor& cursor);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Enable or disable automatic key-repeat
+    ///
+    /// If key repeat is enabled, you will receive repeated
+    /// KeyPressed events while keeping a key pressed. If it is disabled,
+    /// you will only get a single event when the key is pressed.
+    ///
+    /// Key repeat is enabled by default.
+    ///
+    /// \param enabled True to enable, false to disable
+    ///
+    ////////////////////////////////////////////////////////////
+    void setKeyRepeatEnabled(bool enabled);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Limit the framerate to a maximum fixed frequency
+    ///
+    /// If a limit is set, the window will use a small delay after
+    /// each call to display() to ensure that the current frame
+    /// lasted long enough to match the framerate limit.
+    /// SFML will try to match the given limit as much as it can,
+    /// but since it internally uses sf::sleep, whose precision
+    /// depends on the underlying OS, the results may be a little
+    /// unprecise as well (for example, you can get 65 FPS when
+    /// requesting 60).
+    ///
+    /// \param limit Framerate limit, in frames per seconds (use 0 to disable limit)
+    ///
+    ////////////////////////////////////////////////////////////
+    void setFramerateLimit(unsigned int limit);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Change the joystick threshold
+    ///
+    /// The joystick threshold is the value below which
+    /// no JoystickMoved event will be generated.
+    ///
+    /// The threshold value is 0.1 by default.
+    ///
+    /// \param threshold New threshold, in the range [0, 100]
+    ///
+    ////////////////////////////////////////////////////////////
+    void setJoystickThreshold(float threshold);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Activate or deactivate the window as the current target
+    ///        for OpenGL rendering
+    ///
+    /// A window is active only on the current thread, if you want to
+    /// make it active on another thread you have to deactivate it
+    /// on the previous thread first if it was active.
+    /// Only one window can be active on a thread at a time, thus
+    /// the window previously active (if any) automatically gets deactivated.
+    /// This is not to be confused with requestFocus().
+    ///
+    /// \param active True to activate, false to deactivate
+    ///
+    /// \return True if operation was successful, false otherwise
+    ///
+    ////////////////////////////////////////////////////////////
+    bool setActive(bool active = true) const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Request the current window to be made the active
+    ///        foreground window
+    ///
+    /// At any given time, only one window may have the input focus
+    /// to receive input events such as keystrokes or mouse events.
+    /// If a window requests focus, it only hints to the operating
+    /// system, that it would like to be focused. The operating system
+    /// is free to deny the request.
+    /// This is not to be confused with setActive().
+    ///
+    /// \see hasFocus
+    ///
+    ////////////////////////////////////////////////////////////
+    void requestFocus();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Check whether the window has the input focus
+    ///
+    /// At any given time, only one window may have the input focus
+    /// to receive input events such as keystrokes or most mouse
+    /// events.
+    ///
+    /// \return True if window has focus, false otherwise
+    /// \see requestFocus
+    ///
+    ////////////////////////////////////////////////////////////
+    bool hasFocus() const;
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Display on screen what has been rendered to the window so far
+    ///
+    /// This function is typically called after all OpenGL rendering
+    /// has been done for the current frame, in order to show
+    /// it on screen.
+    ///
+    ////////////////////////////////////////////////////////////
+    void display();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Get the OS-specific handle of the window
+    ///
+    /// The type of the returned handle is sf::WindowHandle,
+    /// which is a typedef to the handle type defined by the OS.
+    /// You shouldn't need to use this function, unless you have
+    /// very specific stuff to implement that SFML doesn't support,
+    /// or implement a temporary workaround until a bug is fixed.
+    ///
+    /// \return System handle of the window
+    ///
+    ////////////////////////////////////////////////////////////
+    WindowHandle getSystemHandle() const;
+
+protected:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Function called after the window has been created
+    ///
+    /// This function is called so that derived classes can
+    /// perform their own specific initialization as soon as
+    /// the window is created.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onCreate();
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Function called after the window has been resized
+    ///
+    /// This function is called so that derived classes can
+    /// perform custom actions when the size of the window changes.
+    ///
+    ////////////////////////////////////////////////////////////
+    virtual void onResize();
+
+private:
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Processes an event before it is sent to the user
+    ///
+    /// This function is called every time an event is received
+    /// from the internal window (through pollEvent or waitEvent).
+    /// It filters out unwanted events, and performs whatever internal
+    /// stuff the window needs before the event is returned to the
+    /// user.
+    ///
+    /// \param event Event to filter
+    ///
+    ////////////////////////////////////////////////////////////
+    bool filterEvent(const Event& event);
+
+    ////////////////////////////////////////////////////////////
+    /// \brief Perform some common internal initializations
+    ///
+    ////////////////////////////////////////////////////////////
+    void initialize();
+
+    ////////////////////////////////////////////////////////////
+    // Member data
+    ////////////////////////////////////////////////////////////
+    priv::WindowImpl* m_impl;           ///< Platform-specific implementation of the window
+    priv::GlContext*  m_context;        ///< Platform-specific implementation of the OpenGL context
+    Clock             m_clock;          ///< Clock for measuring the elapsed time between frames
+    Time              m_frameTimeLimit; ///< Current framerate limit
+    Vector2u          m_size;           ///< Current size of the window
+};
+
+} // namespace sf
+
+
+#endif // SFML_WINDOW_HPP
+
+
+////////////////////////////////////////////////////////////
+/// \class sf::Window
+/// \ingroup window
+///
+/// sf::Window is the main class of the Window module. It defines
+/// an OS window that is able to receive an OpenGL rendering.
+///
+/// A sf::Window can create its own new window, or be embedded into
+/// an already existing control using the create(handle) function.
+/// This can be useful for embedding an OpenGL rendering area into
+/// a view which is part of a bigger GUI with existing windows,
+/// controls, etc. It can also serve as embedding an OpenGL rendering
+/// area into a window created by another (probably richer) GUI library
+/// like Qt or wxWidgets.
+///
+/// The sf::Window class provides a simple interface for manipulating
+/// the window: move, resize, show/hide, control mouse cursor, etc.
+/// It also provides event handling through its pollEvent() and waitEvent()
+/// functions.
+///
+/// Note that OpenGL experts can pass their own parameters (antialiasing
+/// level, bits for the depth and stencil buffers, etc.) to the
+/// OpenGL context attached to the window, with the sf::ContextSettings
+/// structure which is passed as an optional argument when creating the
+/// window.
+///
+/// On dual-graphics systems consisting of a low-power integrated GPU
+/// and a powerful discrete GPU, the driver picks which GPU will run an
+/// SFML application. In order to inform the driver that an SFML application
+/// can benefit from being run on the more powerful discrete GPU,
+/// #SFML_DEFINE_DISCRETE_GPU_PREFERENCE can be placed in a source file
+/// that is compiled and linked into the final application. The macro
+/// should be placed outside of any scopes in the global namespace.
+///
+/// Usage example:
+/// \code
+/// // Declare and create a new window
+/// sf::Window window(sf::VideoMode(800, 600), "SFML window");
+///
+/// // Limit the framerate to 60 frames per second (this step is optional)
+/// window.setFramerateLimit(60);
+///
+/// // The main loop - ends as soon as the window is closed
+/// while (window.isOpen())
+/// {
+///    // Event processing
+///    sf::Event event;
+///    while (window.pollEvent(event))
+///    {
+///        // Request for closing the window
+///        if (event.type == sf::Event::Closed)
+///            window.close();
+///    }
+///
+///    // Activate the window for OpenGL rendering
+///    window.setActive();
+///
+///    // OpenGL drawing commands go here...
+///
+///    // End the current frame and display its contents on screen
+///    window.display();
+/// }
+/// \endcode
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/WindowHandle.hpp
+++ b/libs/include/SFML/Window/WindowHandle.hpp
@@ -1,0 +1,101 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_WINDOWHANDLE_HPP
+#define SFML_WINDOWHANDLE_HPP
+
+////////////////////////////////////////////////////////////
+// Headers
+////////////////////////////////////////////////////////////
+#include <SFML/Config.hpp>
+
+// Windows' HWND is a typedef on struct HWND__*
+#if defined(SFML_SYSTEM_WINDOWS)
+    struct HWND__;
+#endif
+
+namespace sf
+{
+#if defined(SFML_SYSTEM_WINDOWS)
+
+    // Window handle is HWND (HWND__*) on Windows
+    typedef HWND__* WindowHandle;
+
+#elif defined(SFML_SYSTEM_LINUX) || defined(SFML_SYSTEM_FREEBSD) || defined(SFML_SYSTEM_OPENBSD)
+
+    // Window handle is Window (unsigned long) on Unix - X11
+    typedef unsigned long WindowHandle;
+
+#elif defined(SFML_SYSTEM_MACOS)
+
+    // Window handle is NSWindow or NSView (void*) on Mac OS X - Cocoa
+    typedef void* WindowHandle;
+
+#elif defined(SFML_SYSTEM_IOS)
+
+    // Window handle is UIWindow (void*) on iOS - UIKit
+    typedef void* WindowHandle;
+
+#elif defined(SFML_SYSTEM_ANDROID)
+
+    // Window handle is ANativeWindow* (void*) on Android
+    typedef void* WindowHandle;
+
+#elif defined(SFML_DOXYGEN)
+
+    // Define typedef symbol so that Doxygen can attach some documentation to it
+    typedef "platform-specific" WindowHandle;
+
+#endif
+
+} // namespace sf
+
+
+#endif // SFML_WINDOWHANDLE_HPP
+
+////////////////////////////////////////////////////////////
+/// \typedef sf::WindowHandle
+/// \ingroup window
+///
+/// Define a low-level window handle type, specific to
+/// each platform.
+///
+/// Platform        | Type
+/// ----------------|------------------------------------------------------------
+/// Windows         | \p HWND
+/// Linux/FreeBSD   | \p %Window
+/// Mac OS X        | either \p NSWindow* or \p NSView*, disguised as \p void*
+/// iOS             | \p UIWindow*
+/// Android         | \p ANativeWindow*
+///
+/// \par Mac OS X Specification
+///
+/// On Mac OS X, a sf::Window can be created either from an
+/// existing \p NSWindow* or an \p NSView*. When the window
+/// is created from a window, SFML will use its content view
+/// as the OpenGL area. sf::Window::getSystemHandle() will
+/// return the handle that was used to create the window,
+/// which is a \p NSWindow* by default.
+///
+////////////////////////////////////////////////////////////

--- a/libs/include/SFML/Window/WindowStyle.hpp
+++ b/libs/include/SFML/Window/WindowStyle.hpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////
+//
+// SFML - Simple and Fast Multimedia Library
+// Copyright (C) 2007-2018 Laurent Gomila (laurent@sfml-dev.org)
+//
+// This software is provided 'as-is', without any express or implied warranty.
+// In no event will the authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it freely,
+// subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented;
+//    you must not claim that you wrote the original software.
+//    If you use this software in a product, an acknowledgment
+//    in the product documentation would be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such,
+//    and must not be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+////////////////////////////////////////////////////////////
+
+#ifndef SFML_WINDOWSTYLE_HPP
+#define SFML_WINDOWSTYLE_HPP
+
+
+namespace sf
+{
+namespace Style
+{
+    ////////////////////////////////////////////////////////////
+    /// \ingroup window
+    /// \brief Enumeration of the window styles
+    ///
+    ////////////////////////////////////////////////////////////
+    enum
+    {
+        None       = 0,      ///< No border / title bar (this flag and all others are mutually exclusive)
+        Titlebar   = 1 << 0, ///< Title bar + fixed border
+        Resize     = 1 << 1, ///< Title bar + resizable border + maximize button
+        Close      = 1 << 2, ///< Title bar + close button
+        Fullscreen = 1 << 3, ///< Fullscreen mode (this flag and all others are mutually exclusive)
+
+        Default = Titlebar | Resize | Close ///< Default window style
+    };
+}
+
+} // namespace sf
+
+
+#endif // SFML_WINDOWSTYLE_HPP

--- a/sfcomp.py
+++ b/sfcomp.py
@@ -1,30 +1,31 @@
 #!/usr/bin/python
-from os import listdir, system
+from os import listdir, system, path, makedirs
 from sys import argv
 
+repo_dir = path.dirname(path.abspath(__file__))
+obj_dir = repo_dir + "\\obj"
+
+if not path.exists(obj_dir):
+    makedirs(obj_dir)
+
 if '-c' in argv:
-    sysout = 'g++ -c main.cpp '
+    sysout = 'g++ -c '
     classes = [x[:-4] for x in listdir('./classes') if x[-4:] == '.cpp']
     for classname in classes:
         sysout += ("./classes/" + classname + ".cpp ")
     sysout += "./libs/src/TMXParser.cpp "
     sysout += "./libs/src/TSXParser.cpp "
+    sysout += "-Ilibs/include -Llibs/lib -lsfml-graphics -lsfml-window -lsfml-system"
     system(sysout[:-1])
-    sysout = "g++ main.o "
+    sysout = "g++ "
     for classname in classes:
         sysout += classname + ".o "
     sysout += "TMXParser.o "
     sysout += "TSXParser.o "
-    sysout += "-o sfml-app.out -lsfml-graphics -lsfml-window -lsfml-system"
+    sysout += "-o sfml-app.exe -Ilibs/include -Llibs/lib -lsfml-graphics -lsfml-window -lsfml-system"
     system(sysout)
-    sysout = "mv main.o "
-    sysout += "TMXParser.o "
-    sysout += "TSXParser.o "
-    for classname in classes:
-        sysout += classname + ".o "
-    sysout += "./obj/"
+    sysout = "move *.o "
+    sysout += obj_dir
     system(sysout)
 if '-r' in argv:
-    system("./sfml-app.out")
-
-
+    system(".\\sfml-app.exe")


### PR DESCRIPTION
Have modified sfcomp.py and added some files in your libs folder.

For windows users you have to download SFML (currently 2.5.1) which you can do here: https://www.sfml-dev.org/download/sfml/2.5.1/. Download "GCC 7.3.0 MinGW (DW2) - 32-bit".

After downloading it you need to add the base directory of SFML to PATH in Environment Variables. Example of path: "C:\SFML-2.5.1". This is for using the DLL files in the bin folder.

To compile you just need to run sfcomp.py

Added all content in the include and lib directories in this PR. Not all of them are used but they're the default.